### PR TITLE
Tweak the icon-finding code

### DIFF
--- a/src/blogmore/icons.py
+++ b/src/blogmore/icons.py
@@ -46,8 +46,7 @@ def detect_source_icon(
 
     # If a custom filename is provided, check for it
     if custom_filename:
-        custom_path = extras_dir / custom_filename
-        if custom_path.is_file():
+        if (custom_path := extras_dir / Path(custom_filename).name).is_file():
             return custom_path
         return None
 
@@ -62,8 +61,7 @@ def detect_source_icon(
     ]
 
     for candidate in default_candidates:
-        candidate_path = extras_dir / candidate
-        if candidate_path.is_file():
+        if (candidate_path := extras_dir / candidate).is_file():
             return candidate_path
 
     return None


### PR DESCRIPTION
The docs say that the icon file name is just that, a file name, but it was possible to make it a path relative to the extras directory, which doesn't make a heap of sense. So this change cleans the incoming icon file name if there is one and only uses the actual name.

I'm not keen on the fact that I started out doing this pulling a file from the `extras` directory; in retrospect I think I should have made the icon file a path to an image anywhere in the user's filesystem. I might make that a 2.0 change and deprecate the "look in extras for common names or used a given name" approach.