### PR TITLE
Remove the word count and reading time duplication of effort

### DIFF
--- a/src/blogmore/utils.py
+++ b/src/blogmore/utils.py
@@ -3,7 +3,7 @@
 import re
 
 
-def _strip_markdown_and_html(content: str) -> str:
+def strip_markdown(content: str) -> str:
     """Remove common Markdown and HTML formatting from content.
 
     Args:
@@ -11,24 +11,26 @@ def _strip_markdown_and_html(content: str) -> str:
 
     Returns:
         The cleaned text with formatting removed.
+
+    Note:
+        This is *not* a full Markdown to plain text converter. It handles
+        common formatting characters and structures, but may not cover all
+        edge cases or extensions. The main goal is to remove formatting
+        characters that would interfere with things like word counting,
+        while preserving the actual text content.
     """
     # Remove code blocks
     content = re.sub(r"```[\s\S]*?```", "", content)
-    content = re.sub(r"`[^`]+`", "", content)
-
-    # Remove markdown links but keep the text: [text](url) -> text
-    content = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", content)
-
     # Remove markdown images: ![alt](url) -> ""
     content = re.sub(r"!\[([^\]]*)\]\([^\)]+\)", "", content)
-
+    # Remove markdown links but keep the text: [text](url) -> text
+    content = re.sub(r"\[([^\]]*)\]\([^\)]+\)", r"\1", content)
     # Remove HTML tags
     content = re.sub(r"<[^>]+>", "", content)
-
     # Remove markdown formatting characters
     content = re.sub(r"[*_~`#-]", " ", content)
-
-    return content
+    # Collapse multiple spaces into one.
+    return re.sub(r"\s+", " ", content).strip()
 
 
 def count_words(content: str) -> int:
@@ -46,7 +48,7 @@ def count_words(content: str) -> int:
         >>> count_words("word " * 10)
         10
     """
-    return len([word for word in _strip_markdown_and_html(content).split() if word])
+    return len([word for word in strip_markdown(content).split() if word])
 
 
 def calculate_reading_time(content: str, words_per_minute: int = 200) -> int:

--- a/src/blogmore/utils.py
+++ b/src/blogmore/utils.py
@@ -3,24 +3,14 @@
 import re
 
 
-def count_words(content: str) -> int:
-    """Count the number of words in the given content.
-
-    Strips common Markdown and HTML formatting before counting so that only
-    prose words are included.  The same normalisation rules as
-    :func:`calculate_reading_time` are applied.
+def _strip_markdown_and_html(content: str) -> str:
+    """Remove common Markdown and HTML formatting from content.
 
     Args:
-        content: The text content to analyse (may include Markdown/HTML).
+        content: The text content to clean up.
 
     Returns:
-        The number of words in the content.
-
-    Examples:
-        >>> count_words("Hello world")
-        2
-        >>> count_words("word " * 10)
-        10
+        The cleaned text with formatting removed.
     """
     # Remove code blocks
     content = re.sub(r"```[\s\S]*?```", "", content)
@@ -38,21 +28,36 @@ def count_words(content: str) -> int:
     # Remove markdown formatting characters
     content = re.sub(r"[*_~`#-]", " ", content)
 
-    return len([word for word in content.split() if word])
+    return content
+
+
+def count_words(content: str) -> int:
+    """Count the number of words in the given content.
+
+    Args:
+        content: The text content to analyse (may include Markdown/HTML).
+
+    Returns:
+        The number of words in the content.
+
+    Examples:
+        >>> count_words("Hello world")
+        2
+        >>> count_words("word " * 10)
+        10
+    """
+    return len([word for word in _strip_markdown_and_html(content).split() if word])
 
 
 def calculate_reading_time(content: str, words_per_minute: int = 200) -> int:
     """Calculate the estimated reading time for content in whole minutes.
 
-    Uses the standard reading speed of 200 words per minute. Strips markdown
-    formatting and counts only actual words to provide an accurate estimate.
-
     Args:
-        content: The text content to analyze (can include markdown)
+        content: The text content to analyse (can include markdown)
         words_per_minute: Average reading speed (default: 200 WPM)
 
     Returns:
-        Estimated reading time in whole minutes (minimum 1 minute)
+        Estimated reading time in whole minutes (minimum 1 minute).
 
     Examples:
         >>> calculate_reading_time("Hello world")
@@ -60,30 +65,7 @@ def calculate_reading_time(content: str, words_per_minute: int = 200) -> int:
         >>> calculate_reading_time("word " * 400)
         2
     """
-    # Remove code blocks (they typically take longer to read/understand)
-    content = re.sub(r"```[\s\S]*?```", "", content)
-    content = re.sub(r"`[^`]+`", "", content)
-
-    # Remove markdown links but keep the text: [text](url) -> text
-    content = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", content)
-
-    # Remove markdown images: ![alt](url) -> ""
-    content = re.sub(r"!\[([^\]]*)\]\([^\)]+\)", "", content)
-
-    # Remove HTML tags
-    content = re.sub(r"<[^>]+>", "", content)
-
-    # Remove markdown formatting characters
-    content = re.sub(r"[*_~`#-]", " ", content)
-
-    # Count words (split by whitespace and filter out empty strings)
-    words = [word for word in content.split() if word]
-    word_count = len(words)
-
-    # Calculate minutes, rounding to the nearest minute with a minimum of 1
-    minutes = max(1, round(word_count / words_per_minute))
-
-    return minutes
+    return max(1, round(count_words(content) / words_per_minute))
 
 
 def make_urls_absolute(html_content: str, base_url: str) -> str:
@@ -152,3 +134,6 @@ def normalize_site_url(site_url: str) -> str:
         ""
     """
     return site_url.rstrip("/") if site_url else ""
+
+
+### utils.py ends here

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,76 @@ from blogmore.utils import (
     calculate_reading_time,
     make_urls_absolute,
     normalize_site_url,
+    strip_markdown,
 )
+
+
+class TestStripMarkdown:
+    """Test the strip_markdown function."""
+
+    def test_strip_markdown_basic(self) -> None:
+        """Test that basic markdown formatting is stripped."""
+        content = "**Bold** and *italic* and `code` and [link](url)"
+        assert strip_markdown(content) == "Bold and italic and code and link"
+
+    def test_strip_markdown_with_images(self) -> None:
+        """Test that markdown images are removed."""
+        content = "Here is an image: ![Alt text](image.jpg) and some more text."
+        assert strip_markdown(content) == "Here is an image: and some more text."
+        content = "Here is an image: ![](image.jpg) and some more text."
+        assert strip_markdown(content) == "Here is an image: and some more text."
+
+    def test_strip_markdown_with_html_tags(self) -> None:
+        """Test that HTML tags are removed."""
+        content = "<p>This is a paragraph</p> with <strong>HTML tags</strong>."
+        assert strip_markdown(content) == "This is a paragraph with HTML tags."
+
+    def test_strip_markdown_with_code_blocks(self) -> None:
+        """Test that code blocks are removed."""
+        content = """
+        This is some text before the code.
+
+        ```python
+        def hello():
+            print("This code should not be counted")
+            return "lots of words here"
+        ```
+
+        This is text after the code.
+        """
+        assert (
+            strip_markdown(content)
+            == "This is some text before the code. This is text after the code."
+        )
+
+    def test_strip_markdown_empty_string(self) -> None:
+        """Test that an empty string returns an empty string."""
+        assert strip_markdown("") == ""
+
+    def test_strip_markdown_only_formatting(self) -> None:
+        """Test that a string with only formatting characters returns an empty string."""
+        content = "***___```###"
+        assert strip_markdown(content) == ""
+
+    def test_strip_markdown_with_nested_formatting(self) -> None:
+        """Test that nested formatting characters are all stripped."""
+        content = "**Bold and *nested italic* text**"
+        assert strip_markdown(content) == "Bold and nested italic text"
+
+    def test_strip_markdown_with_links_and_images(self) -> None:
+        """Test that links are stripped but their text is preserved, while images are removed."""
+        content = "This is a [link](url) and this is an image: ![Alt](img.jpg)"
+        assert strip_markdown(content) == "This is a link and this is an image:"
+
+    def test_strip_markdown_with_linked_image(self) -> None:
+        """Test that linked images are stripped but their alt text is preserved."""
+        content = "Here is a linked image: [![Alt](img.jpg)](url)"
+        assert strip_markdown(content) == "Here is a linked image:"
+
+    def test_strip_markdown_preserves_newlines_as_spaces(self) -> None:
+        """Test that newlines are preserved as spaces."""
+        content = "Line one.\nLine two.\n\nLine three."
+        assert strip_markdown(content) == "Line one. Line two. Line three."
 
 
 class TestCalculateReadingTime:
@@ -36,13 +105,13 @@ class TestCalculateReadingTime:
         """Test that code blocks are removed before counting."""
         content = """
         This is some text before the code.
-        
+
         ```python
         def hello():
             print("This code should not be counted")
             return "lots of words here"
         ```
-        
+
         This is text after the code.
         """
         # Should count: "This is some text before the code" (7) + "This is text after the code" (6) = 13 words
@@ -165,10 +234,7 @@ class TestMakeUrlsAbsolute:
 
     def test_multiple_attributes_in_one_call(self) -> None:
         """Test that multiple relative attributes are all rewritten."""
-        html = (
-            '<img src="/img/banner.png">'
-            '<a href="/posts/hello.html">Hello</a>'
-        )
+        html = '<img src="/img/banner.png">' '<a href="/posts/hello.html">Hello</a>'
         result = make_urls_absolute(html, "https://example.com")
         assert 'src="https://example.com/img/banner.png"' in result
         assert 'href="https://example.com/posts/hello.html"' in result
@@ -183,10 +249,15 @@ class TestMakeUrlsAbsolute:
         """Test rewriting a deeply nested root-relative path."""
         html = '<img src="/attachments/2026/02/11/banner.png">'
         result = make_urls_absolute(html, "https://myblog.com")
-        assert result == '<img src="https://myblog.com/attachments/2026/02/11/banner.png">'
+        assert (
+            result == '<img src="https://myblog.com/attachments/2026/02/11/banner.png">'
+        )
 
     def test_no_relative_urls_returns_unchanged(self) -> None:
         """Test that HTML with no relative URLs is returned unchanged."""
         html = "<p>Hello world</p>"
         result = make_urls_absolute(html, "https://example.com")
         assert result == html
+
+
+### test_utils.py ends here


### PR DESCRIPTION
Stemming from: https://blog.davep.org/2026/04/30/duplication-of-effort.html

The more I look at this, the less I'm a fan of the Markdown/HTML strip function in `utils.py`. While it's "good enough" it also feels like a hack. There's a tool in the markdown module that converts Markdown into plain text (it's used for working out the first paragraph plus backlink context content) and I sense that word counting and reading time calculation should use that. However, at the moment, it doesn't strip fenced code blocks and word count and reading time arguably should.

So I'll roll with this now, but raise an issue to properly refactor this at some point soon so there's a proper utility function for turning Markdown into workable plain text, with options.

This is almost starting to feel like I should spin out a proper Markdown utils library.