### PR TITLE
Tidy path/email template expansion code

### DIFF
--- a/src/blogmore/comment_invite.py
+++ b/src/blogmore/comment_invite.py
@@ -7,81 +7,11 @@ from urllib.parse import quote
 ##############################################################################
 # Application imports.
 from blogmore.content_path import resolve_path
-from blogmore.parser import Post, remove_date_prefix, sanitize_for_url
+from blogmore.parser import Post
+from blogmore.post_path import get_post_path_variables
+
 
 ##############################################################################
-# The set of variable names that may appear in an invite_comments_to template.
-# Identical to the set used for post_path templates.
-ALLOWED_EMAIL_VARIABLES = frozenset(
-    {
-        "year",
-        "month",
-        "day",
-        "hour",
-        "minute",
-        "second",
-        "category",
-        "author",
-        "slug",
-    }
-)
-
-
-def resolve_invite_email_template(post: "Post", template: str) -> str:
-    """Expand an ``invite_comments_to`` template string for a given post.
-
-    Substitutes all recognised variable placeholders in *template* with
-    values derived from *post*.  Posts that have no date will use empty
-    strings for date and time components.  Unlike ``post_path`` templates,
-    the ``{slug}`` placeholder is **not** required.
-
-    Args:
-        post: The post whose metadata is used to fill the template.
-        template: A format string containing ``{variable}`` placeholders.
-
-    Returns:
-        The expanded string with all placeholders replaced by post-derived
-        values.
-
-    Raises:
-        ValueError: If the template references an unknown variable or is
-            otherwise malformed.
-    """
-    slug = remove_date_prefix(post.slug)
-
-    author = ""
-    if post.metadata:
-        raw_author = post.metadata.get("author")
-        if raw_author:
-            author = sanitize_for_url(str(raw_author))
-
-    category = post.safe_category or ""
-
-    if post.date:
-        year = str(post.date.year)
-        month = f"{post.date.month:02d}"
-        day = f"{post.date.day:02d}"
-        hour = f"{post.date.hour:02d}"
-        minute = f"{post.date.minute:02d}"
-        second = f"{post.date.second:02d}"
-    else:
-        year = month = day = hour = minute = second = ""
-
-    variables = {
-        "year": year,
-        "month": month,
-        "day": day,
-        "hour": hour,
-        "minute": minute,
-        "second": second,
-        "category": category,
-        "author": author,
-        "slug": slug,
-    }
-
-    return resolve_path(variables, template, "invite_comments_to")
-
-
 def get_invite_email_for_post(
     post: "Post", invite_comments: bool, invite_comments_to: str | None
 ) -> str | None:
@@ -114,11 +44,14 @@ def get_invite_email_for_post(
         return str(raw) if raw else None
 
     if invite_comments_to:
-        return resolve_invite_email_template(post, invite_comments_to)
+        return resolve_path(
+            get_post_path_variables(post), invite_comments_to, "invite_comments_to"
+        )
 
     return None
 
 
+##############################################################################
 def build_mailto_url(email: str, subject: str) -> str:
     """Build a ``mailto:`` URL with a URL-encoded subject.
 

--- a/src/blogmore/content_path.py
+++ b/src/blogmore/content_path.py
@@ -16,8 +16,9 @@ from string import Formatter
 def validate_path_template(
     template: str,
     config_key: str,
-    allowed_variables: frozenset[str],
+    allowed_variables: set[str],
     item_name: str,
+    required_variables: set[str] | None = None,
 ) -> None:
     """Validate a path format string for a content type.
 
@@ -41,29 +42,34 @@ def validate_path_template(
     if not template:
         raise ValueError(f"{config_key} must not be empty")
 
+    if required_variables and not required_variables.issubset(allowed_variables):
+        raise ValueError(
+            f"Internal error: required_variables must be a subset of allowed_variables"
+        )
+
     # Extract field names using the standard Formatter parser.
     try:
-        field_names = [
+        field_names = {
             field_name
             for _, field_name, _, _ in Formatter().parse(template)
             if field_name is not None
-        ]
+        }
     except (ValueError, KeyError) as error:
         raise ValueError(
             f"{config_key} '{template}' contains an invalid placeholder: {error}"
         ) from error
 
-    if unknown := (set(field_names) - allowed_variables):
+    if unknown := (field_names - allowed_variables):
         raise ValueError(
             f"{config_key} '{template}' contains unknown variable(s): "
             + ", ".join(sorted(unknown))
             + f". Allowed variables are: {', '.join(sorted(allowed_variables))}"
         )
 
-    if "slug" not in field_names:
+    if missing := ((required_variables or set()) - field_names):
         raise ValueError(
-            f"{config_key} '{template}' must contain the {{slug}} variable so that "
-            f"each {item_name} can be uniquely identified"
+            f"{config_key} '{template}' is missing required variable(s): "
+            + ", ".join([f"{{{variable}}}" for variable in sorted(missing)])
         )
 
 

--- a/src/blogmore/content_path.py
+++ b/src/blogmore/content_path.py
@@ -44,7 +44,7 @@ def validate_path_template(
 
     if required_variables and not required_variables.issubset(allowed_variables):
         raise ValueError(
-            f"Internal error: required_variables must be a subset of allowed_variables"
+            "Internal error: required_variables must be a subset of allowed_variables"
         )
 
     # Extract field names using the standard Formatter parser.

--- a/src/blogmore/content_path.py
+++ b/src/blogmore/content_path.py
@@ -53,8 +53,7 @@ def validate_path_template(
             f"{config_key} '{template}' contains an invalid placeholder: {error}"
         ) from error
 
-    unknown = set(field_names) - allowed_variables
-    if unknown:
+    if unknown := (set(field_names) - allowed_variables):
         raise ValueError(
             f"{config_key} '{template}' contains unknown variable(s): "
             + ", ".join(sorted(unknown))

--- a/src/blogmore/page_path.py
+++ b/src/blogmore/page_path.py
@@ -3,6 +3,7 @@
 ##############################################################################
 # Standard-library imports.
 from pathlib import Path
+from typing import Final
 
 ##############################################################################
 # Application imports.
@@ -17,7 +18,7 @@ DEFAULT_PAGE_PATH = "{slug}.html"
 # The set of variable names that may appear in a page_path template.
 # Pages have no date, category, or author metadata, so the only meaningful
 # variable is the page slug.
-ALLOWED_PAGE_PATH_VARIABLES = frozenset({"slug"})
+ALLOWED_PAGE_PATH_VARIABLES: Final[set[str]] = {"slug"}
 
 
 def validate_page_path_template(template: str) -> None:
@@ -33,7 +34,13 @@ def validate_page_path_template(template: str) -> None:
         ValueError: If the template is empty, contains no ``{slug}``
             placeholder, or references an unknown variable name.
     """
-    validate_path_template(template, "page_path", ALLOWED_PAGE_PATH_VARIABLES, "page")
+    validate_path_template(
+        template,
+        "page_path",
+        ALLOWED_PAGE_PATH_VARIABLES,
+        "page",
+        ALLOWED_PAGE_PATH_VARIABLES,
+    )
 
 
 def resolve_page_path(page: Page, template: str) -> str:

--- a/src/blogmore/pagination_path.py
+++ b/src/blogmore/pagination_path.py
@@ -2,21 +2,23 @@
 
 ##############################################################################
 # Python imports.
-import re
-from string import Formatter
+from typing import Final
 
 ##############################################################################
-# Default pagination path templates (match historical BlogMore behaviour).
+# Local imports.
+from blogmore.content_path import resolve_path, validate_path_template
+
+##############################################################################
+# Default pagination path templates.
 DEFAULT_PAGE_1_PATH = "index.html"
 DEFAULT_PAGE_N_PATH = "page/{page}.html"
 
 ##############################################################################
 # The set of variable names that may appear in a pagination path template.
-# The only meaningful variable is the page number.
-ALLOWED_PAGE_1_PATH_VARIABLES = frozenset({"page"})
-ALLOWED_PAGE_N_PATH_VARIABLES = frozenset({"page"})
+ALLOWED_PAGE_PATH_VARIABLES: Final[set[str]] = {"page"}
 
 
+##############################################################################
 def validate_page_1_path_template(template: str) -> None:
     """Validate a page_1_path format string.
 
@@ -32,29 +34,15 @@ def validate_page_1_path_template(template: str) -> None:
         ValueError: If the template is empty or references an unknown
             variable name.
     """
-    if not template:
-        raise ValueError("page_1_path must not be empty")
-
-    try:
-        field_names = [
-            field_name
-            for _, field_name, _, _ in Formatter().parse(template)
-            if field_name is not None
-        ]
-    except (ValueError, KeyError) as error:
-        raise ValueError(
-            f"page_1_path '{template}' contains an invalid placeholder: {error}"
-        ) from error
-
-    unknown = set(field_names) - ALLOWED_PAGE_1_PATH_VARIABLES
-    if unknown:
-        raise ValueError(
-            f"page_1_path '{template}' contains unknown variable(s): "
-            + ", ".join(sorted(unknown))
-            + f". Allowed variables are: {', '.join(sorted(ALLOWED_PAGE_1_PATH_VARIABLES))}"
-        )
+    validate_path_template(
+        template,
+        "page_1_path",
+        ALLOWED_PAGE_PATH_VARIABLES,
+        "index page",
+    )
 
 
+##############################################################################
 def validate_page_n_path_template(template: str) -> None:
     """Validate a page_n_path format string.
 
@@ -70,35 +58,16 @@ def validate_page_n_path_template(template: str) -> None:
         ValueError: If the template is empty, contains no ``{page}``
             placeholder, or references an unknown variable name.
     """
-    if not template:
-        raise ValueError("page_n_path must not be empty")
-
-    try:
-        field_names = [
-            field_name
-            for _, field_name, _, _ in Formatter().parse(template)
-            if field_name is not None
-        ]
-    except (ValueError, KeyError) as error:
-        raise ValueError(
-            f"page_n_path '{template}' contains an invalid placeholder: {error}"
-        ) from error
-
-    unknown = set(field_names) - ALLOWED_PAGE_N_PATH_VARIABLES
-    if unknown:
-        raise ValueError(
-            f"page_n_path '{template}' contains unknown variable(s): "
-            + ", ".join(sorted(unknown))
-            + f". Allowed variables are: {', '.join(sorted(ALLOWED_PAGE_N_PATH_VARIABLES))}"
-        )
-
-    if "page" not in field_names:
-        raise ValueError(
-            f"page_n_path '{template}' must contain the {{page}} variable so that "
-            "each subsequent page can be uniquely identified"
-        )
+    validate_path_template(
+        template,
+        "page_n_path",
+        ALLOWED_PAGE_PATH_VARIABLES,
+        "subsequent page",
+        required_variables=ALLOWED_PAGE_PATH_VARIABLES,
+    )
 
 
+##############################################################################
 def resolve_pagination_page_path(template: str, page: int) -> str:
     """Resolve a pagination path template for a given page number.
 
@@ -117,15 +86,7 @@ def resolve_pagination_page_path(template: str, page: int) -> str:
         A relative path string (no leading slash) derived from the
         template.
     """
-    try:
-        result = template.format(page=page)
-    except (KeyError, ValueError) as error:
-        raise ValueError(
-            f"Failed to resolve pagination path template '{template}': {error}"
-        ) from error
-
-    result = re.sub(r"/+", "/", result)
-    return result.lstrip("/")
+    return resolve_path({"page": str(page)}, template, "pagination path")
 
 
 ### pagination_path.py ends here

--- a/src/blogmore/post_path.py
+++ b/src/blogmore/post_path.py
@@ -3,6 +3,7 @@
 ##############################################################################
 # Python imports.
 from pathlib import Path
+from typing import Final
 
 ##############################################################################
 # Application imports.
@@ -15,19 +16,17 @@ DEFAULT_POST_PATH = "{year}/{month}/{day}/{slug}.html"
 
 ##############################################################################
 # The set of variable names that may appear in a post_path template.
-ALLOWED_PATH_VARIABLES = frozenset(
-    {
-        "year",
-        "month",
-        "day",
-        "hour",
-        "minute",
-        "second",
-        "category",
-        "author",
-        "slug",
-    }
-)
+ALLOWED_PATH_VARIABLES: Final[set[str]] = {
+    "year",
+    "month",
+    "day",
+    "hour",
+    "minute",
+    "second",
+    "category",
+    "author",
+    "slug",
+}
 
 
 def validate_post_path_template(template: str) -> None:
@@ -43,7 +42,9 @@ def validate_post_path_template(template: str) -> None:
         ValueError: If the template is empty, contains no ``{slug}``
             placeholder, or references an unknown variable name.
     """
-    validate_path_template(template, "post_path", ALLOWED_PATH_VARIABLES, "post")
+    validate_path_template(
+        template, "post_path", ALLOWED_PATH_VARIABLES, "post", {"slug"}
+    )
 
 
 def resolve_post_path(post: Post, template: str) -> str:

--- a/src/blogmore/post_path.py
+++ b/src/blogmore/post_path.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from typing import Final
 
 ##############################################################################
-# Application imports.
+# Local imports.
 from blogmore.content_path import resolve_path, safe_output_path, validate_path_template
 from blogmore.parser import Post, remove_date_prefix, sanitize_for_url
 
 ##############################################################################
-# Default post path template (matches historical BlogMore behaviour).
+# Default post path template.
 DEFAULT_POST_PATH = "{year}/{month}/{day}/{slug}.html"
 
 ##############################################################################
@@ -29,6 +29,7 @@ ALLOWED_PATH_VARIABLES: Final[set[str]] = {
 }
 
 
+##############################################################################
 def validate_post_path_template(template: str) -> None:
     """Validate a post_path format string.
 
@@ -39,7 +40,7 @@ def validate_post_path_template(template: str) -> None:
         template: The post_path format string to validate.
 
     Raises:
-        ValueError: If the template is empty, contains no ``{slug}``
+        ValueError: If the template is empty, contains no `{slug}`
             placeholder, or references an unknown variable name.
     """
     validate_path_template(
@@ -85,19 +86,20 @@ def get_post_path_variables(post: Post) -> dict[str, str]:
     }
 
 
+##############################################################################
 def resolve_post_path(post: Post, template: str) -> str:
     """Resolve a post_path template for a given post.
 
-    Substitutes all recognised variable placeholders in *template* with
-    values derived from *post*.  Posts that have no date will use empty
-    strings for date and time components.  Multiple consecutive forward
+    Substitutes all recognised variable placeholders in `template` with
+    values derived from `post`. Posts that have no date will use empty
+    strings for date and time components. Multiple consecutive forward
     slashes that may appear after substitution are collapsed to a single
-    slash, and any leading slash is removed so that the result can safely
-    be joined onto an output directory path.
+    slash, and any leading slash is removed so that the result can safely be
+    joined onto an output directory path.
 
     Args:
         post: The post whose metadata is used to fill the template.
-        template: A format string containing ``{variable}`` placeholders.
+        template: A format string containing `{variable}` placeholders.
 
     Returns:
         A relative path string (no leading slash) derived by substituting
@@ -110,11 +112,12 @@ def resolve_post_path(post: Post, template: str) -> str:
     return resolve_path(get_post_path_variables(post), template, "post_path")
 
 
+##############################################################################
 def compute_output_path(output_dir: Path, post: Post, template: str) -> Path:
     """Compute the safe, absolute output file path for a post.
 
     Resolves *template* using the post's metadata and joins the result onto
-    *output_dir*.  The resolved path is checked to ensure it does not escape
+    `output_dir`. The resolved path is checked to ensure it does not escape
     the output directory (preventing accidental path-traversal writes).
 
     Args:

--- a/src/blogmore/post_path.py
+++ b/src/blogmore/post_path.py
@@ -47,6 +47,44 @@ def validate_post_path_template(template: str) -> None:
     )
 
 
+##############################################################################
+def get_post_path_variables(post: Post) -> dict[str, str]:
+    """Get the path-oriented variables from a post.
+
+    Args:
+        post: The post whose metadata is used to fill the template.
+
+    Returns:
+        A dictionary of post-oriented variables and their values.
+    """
+
+    author = ""
+    if post.metadata and (raw_author := post.metadata.get("author")):
+        author = sanitize_for_url(str(raw_author))
+
+    if post.date:
+        year = str(post.date.year)
+        month = f"{post.date.month:02d}"
+        day = f"{post.date.day:02d}"
+        hour = f"{post.date.hour:02d}"
+        minute = f"{post.date.minute:02d}"
+        second = f"{post.date.second:02d}"
+    else:
+        year = month = day = hour = minute = second = ""
+
+    return {
+        "author": author,
+        "category": post.safe_category or "",
+        "day": day,
+        "hour": hour,
+        "minute": minute,
+        "month": month,
+        "second": second,
+        "slug": remove_date_prefix(post.slug),
+        "year": year,
+    }
+
+
 def resolve_post_path(post: Post, template: str) -> str:
     """Resolve a post_path template for a given post.
 
@@ -69,42 +107,7 @@ def resolve_post_path(post: Post, template: str) -> str:
         ValueError: If the template references an unknown variable or is
             otherwise malformed.
     """
-    slug = remove_date_prefix(post.slug)
-
-    # Author – read from metadata, slugify for safe use in URLs/paths.
-    author = ""
-    if post.metadata:
-        raw_author = post.metadata.get("author")
-        if raw_author:
-            author = sanitize_for_url(str(raw_author))
-
-    # Category – already available as a sanitised property on Post.
-    category = post.safe_category or ""
-
-    # Date / time components – empty strings for undated posts.
-    if post.date:
-        year = str(post.date.year)
-        month = f"{post.date.month:02d}"
-        day = f"{post.date.day:02d}"
-        hour = f"{post.date.hour:02d}"
-        minute = f"{post.date.minute:02d}"
-        second = f"{post.date.second:02d}"
-    else:
-        year = month = day = hour = minute = second = ""
-
-    variables = {
-        "year": year,
-        "month": month,
-        "day": day,
-        "hour": hour,
-        "minute": minute,
-        "second": second,
-        "category": category,
-        "author": author,
-        "slug": slug,
-    }
-
-    return resolve_path(variables, template, "post_path")
+    return resolve_path(get_post_path_variables(post), template, "post_path")
 
 
 def compute_output_path(output_dir: Path, post: Post, template: str) -> Path:

--- a/tests/test_comment_invite.py
+++ b/tests/test_comment_invite.py
@@ -11,13 +11,8 @@ import pytest
 
 ##############################################################################
 # Application imports.
-from blogmore.comment_invite import (
-    build_mailto_url,
-    get_invite_email_for_post,
-    resolve_invite_email_template,
-)
+from blogmore.comment_invite import build_mailto_url, get_invite_email_for_post
 from blogmore.parser import Post
-
 
 ##############################################################################
 # Fixtures.
@@ -69,74 +64,6 @@ def post_no_metadata() -> Post:
         draft=False,
         metadata=None,
     )
-
-
-##############################################################################
-# resolve_invite_email_template tests.
-
-
-class TestResolveInviteEmailTemplate:
-    """Tests for resolve_invite_email_template."""
-
-    def test_plain_email_address_unchanged(self, dated_post: Post) -> None:
-        """A plain email address with no placeholders is returned as-is."""
-        result = resolve_invite_email_template(dated_post, "user@example.com")
-        assert result == "user@example.com"
-
-    def test_slug_placeholder(self, dated_post: Post) -> None:
-        """The {slug} placeholder is replaced with the date-stripped slug."""
-        result = resolve_invite_email_template(dated_post, "user+{slug}@example.com")
-        assert result == "user+my-great-article@example.com"
-
-    def test_year_placeholder(self, dated_post: Post) -> None:
-        """The {year} placeholder is replaced with the 4-digit year."""
-        result = resolve_invite_email_template(dated_post, "user+{year}@example.com")
-        assert result == "user+2024@example.com"
-
-    def test_month_placeholder_zero_padded(self, dated_post: Post) -> None:
-        """The {month} placeholder is zero-padded to two digits."""
-        result = resolve_invite_email_template(dated_post, "u+{month}@example.com")
-        assert result == "u+01@example.com"
-
-    def test_day_placeholder_zero_padded(self, dated_post: Post) -> None:
-        """The {day} placeholder is zero-padded to two digits."""
-        result = resolve_invite_email_template(dated_post, "u+{day}@example.com")
-        assert result == "u+15@example.com"
-
-    def test_author_placeholder(self, dated_post: Post) -> None:
-        """The {author} placeholder is replaced with the slugified author."""
-        result = resolve_invite_email_template(dated_post, "{author}@example.com")
-        assert result == "dave-pearson@example.com"
-
-    def test_category_placeholder(self, dated_post: Post) -> None:
-        """The {category} placeholder is replaced with the sanitised category."""
-        result = resolve_invite_email_template(dated_post, "u+{category}@example.com")
-        assert result == "u+python@example.com"
-
-    def test_multiple_placeholders(self, dated_post: Post) -> None:
-        """Multiple placeholders are all replaced correctly."""
-        result = resolve_invite_email_template(
-            dated_post,
-            "{author}+post-{slug}-{year}{month}{day}@{category}.example.com",
-        )
-        assert result == "dave-pearson+post-my-great-article-20240115@python.example.com"
-
-    def test_undated_post_date_variables_empty(self, undated_post: Post) -> None:
-        """Date variables produce empty strings for posts with no date."""
-        result = resolve_invite_email_template(
-            undated_post, "user+{year}{month}{day}@example.com"
-        )
-        assert result == "user+@example.com"
-
-    def test_slug_not_required(self, dated_post: Post) -> None:
-        """A template without {slug} is valid for invite_comments_to."""
-        result = resolve_invite_email_template(dated_post, "static@example.com")
-        assert result == "static@example.com"
-
-    def test_unknown_variable_raises(self, dated_post: Post) -> None:
-        """An unknown placeholder raises ValueError."""
-        with pytest.raises(ValueError):
-            resolve_invite_email_template(dated_post, "{unknown}@example.com")
 
 
 ##############################################################################
@@ -203,7 +130,9 @@ class TestGetInviteEmailForPost:
         dated_post.metadata = dict(dated_post.metadata or {})
         dated_post.metadata["invite_comments_to"] = "specific@example.com"
         result = get_invite_email_for_post(
-            dated_post, invite_comments=True, invite_comments_to="template+{slug}@ex.com"
+            dated_post,
+            invite_comments=True,
+            invite_comments_to="template+{slug}@ex.com",
         )
         assert result == "specific@example.com"
 

--- a/tests/test_content_path.py
+++ b/tests/test_content_path.py
@@ -1,0 +1,69 @@
+from pytest import raises
+
+from blogmore.content_path import validate_path_template
+
+
+class TestValidatePathTemplate:
+    def test_valid_template(self):
+        """Test that a valid template passes validation."""
+        assert validate_path_template("{test}", "tester", {"test"}, "test") is None
+        assert (
+            validate_path_template("prefix/{test}/suffix", "tester", {"test"}, "test")
+            is None
+        )
+        assert validate_path_template("nothing", "tester", set(), "test") is None
+        assert validate_path_template("nothing", "tester", {"test"}, "test") is None
+
+    def test_empty_template(self):
+        """Test that an empty template raises a ValueError."""
+        with raises(ValueError, match="tester must not be empty"):
+            validate_path_template("", "tester", {"test"}, "test")
+
+    def test_unknown_variable(self):
+        """Test that a template with an unknown variable raises a ValueError."""
+        with raises(
+            ValueError, match="tester '.*' contains unknown variable\\(s\\): unknown"
+        ):
+            validate_path_template("{unknown}", "tester", {"test"}, "test")
+
+    def test_malformed_template(self):
+        """Test that a malformed template raises a ValueError."""
+        with raises(
+            ValueError, match="tester '.*' contains an invalid placeholder: .*"
+        ):
+            validate_path_template("{test", "tester", {"test"}, "test")
+        with raises(
+            ValueError, match="tester '.*' contains an invalid placeholder: .*"
+        ):
+            validate_path_template("test}", "tester", {"test"}, "test")
+        with raises(
+            ValueError, match="tester '.*' contains an invalid placeholder: .*"
+        ):
+            validate_path_template("{", "tester", {"test"}, "test")
+        with raises(
+            ValueError, match="tester '.*' contains an invalid placeholder: .*"
+        ):
+            validate_path_template("}", "tester", {"test"}, "test")
+
+    def test_missing_required_variable(self):
+        """Test that a template missing a required variable raises a ValueError."""
+        with raises(
+            ValueError,
+            match="tester '.*' is missing required variable\\(s\\): {required}",
+        ):
+            validate_path_template(
+                "This is a {test}", "tester", {"test", "required"}, "test", {"required"}
+            )
+
+    def test_invalid_required_variable(self):
+        """Test that a template with an invalid required variable raises a ValueError."""
+        with raises(
+            ValueError,
+            match="Internal error: required_variables must be a subset of allowed_variables",
+        ):
+            validate_path_template(
+                "This is a {test}", "tester", {"test"}, "test", {"required"}
+            )
+
+
+### test_content_path.py ends here

--- a/tests/test_pagination_path.py
+++ b/tests/test_pagination_path.py
@@ -1,6 +1,10 @@
 """Tests for the pagination_path module."""
 
 ##############################################################################
+# Python imports.
+import re
+
+##############################################################################
 # Third-party imports.
 import pytest
 
@@ -13,7 +17,6 @@ from blogmore.pagination_path import (
     validate_page_1_path_template,
     validate_page_n_path_template,
 )
-
 
 ##############################################################################
 # Tests for module-level constants.
@@ -40,15 +43,15 @@ class TestValidatePage1PathTemplate:
 
     def test_valid_simple_path(self) -> None:
         """A simple filename with no placeholders is valid."""
-        validate_page_1_path_template("index.html")  # Should not raise
+        assert validate_page_1_path_template("index.html") is None
 
     def test_valid_path_with_subdirectory(self) -> None:
         """A path with subdirectories is valid."""
-        validate_page_1_path_template("pages/index.html")  # Should not raise
+        assert validate_page_1_path_template("pages/index.html") is None
 
     def test_valid_path_with_page_placeholder(self) -> None:
         """The {page} placeholder is allowed in page_1_path."""
-        validate_page_1_path_template("page-{page}.html")  # Should not raise
+        assert validate_page_1_path_template("page-{page}.html") is None
 
     def test_empty_template_raises(self) -> None:
         """An empty template raises ValueError."""
@@ -75,11 +78,11 @@ class TestValidatePageNPathTemplate:
 
     def test_valid_path_with_page_placeholder(self) -> None:
         """A path containing {page} is valid."""
-        validate_page_n_path_template("page/{page}.html")  # Should not raise
+        assert validate_page_n_path_template("page/{page}.html") is None
 
     def test_valid_subdirectory_path_with_page(self) -> None:
         """A path with a subdirectory and {page} is valid."""
-        validate_page_n_path_template("p/{page}/index.html")  # Should not raise
+        assert validate_page_n_path_template("p/{page}/index.html") is None
 
     def test_empty_template_raises(self) -> None:
         """An empty template raises ValueError."""
@@ -88,7 +91,12 @@ class TestValidatePageNPathTemplate:
 
     def test_missing_page_placeholder_raises(self) -> None:
         """A template with no {page} placeholder raises ValueError."""
-        with pytest.raises(ValueError, match="must contain the {page} variable"):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "page_n_path 'pages.html' is missing required variable(s): {page}"
+            ),
+        ):
             validate_page_n_path_template("pages.html")
 
     def test_unknown_variable_raises(self) -> None:
@@ -138,3 +146,6 @@ class TestResolvePaginationPagePath:
         """The {page} placeholder is replaced with the given page number."""
         result = resolve_pagination_page_path("p{page}/index.html", 7)
         assert result == "p7/index.html"
+
+
+### test_pagination_path.py ends here


### PR DESCRIPTION
Various bits of tidying up related to post-based path/email template expansion.

- Tidy up how `validate_path_template` works. Also add some unit tests for it.
- Reduce duplication of code in respect to comment invitation email address expansion.