### PR TITLE
Docstring tidying

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ appropriately-named module rather than growing an existing large file.
   package (e.g. `types-*`) before adding `# type: ignore` comments.
 - Always generate full Google-style docstrings for every module, class,
   method, and function. Do *not* include type information in docstrings.
+- All inline code and cross-references in docstrings **must** use mkdocstrings-compatible Markdown style:
+    - Inline code: use single backticks (\`like_this\`).
+    - Cross-references: use mkdocstrings reference-style Markdown links (e.g., [`ClassName`][module.ClassName] or [module.ClassName][]).
+    - Do **not** use Sphinx roles (e.g., :class:`ClassName`) or double-backtick code (``ClassName``).
 - Docstrings always start on the *same line* as the opening triple quote.
   The closing triple quote is *always* on its own line when the docstring
   is more than one line.

--- a/src/blogmore/backlinks.py
+++ b/src/blogmore/backlinks.py
@@ -3,7 +3,7 @@
 Calculates which posts link to other posts, providing data for a
 "References & mentions" section displayed on individual post pages.
 
-This module is only consulted when ``with_backlinks`` is enabled in the
+This module is only consulted when `with_backlinks` is enabled in the
 site configuration.  When the feature is disabled none of these functions
 are called, so users pay no cost for a feature they do not use.
 """
@@ -53,7 +53,7 @@ class Backlink:
     Attributes:
         source_post: The post whose Markdown content contains the link.
         snippet: HTML-safe excerpt from the source post surrounding the
-            link, with up to ``_SNIPPET_CONTEXT_CHARS`` characters of
+            link, with up to `_SNIPPET_CONTEXT_CHARS` characters of
             context on each side and an ellipsis (``…``) where the
             excerpt is truncated.  The link text itself is wrapped in a
             ``<strong class="backlink-link-text">`` element so it
@@ -74,13 +74,13 @@ def _extract_snippet(
 
     Replaces the matched link syntax in the *full* document with a
     distinctive marker, then converts the entire document to plain text via
-    :func:`~blogmore.markdown.plain_text.markdown_to_plain_text`.  Processing
-    the complete document ensures that all Markdown constructs (fenced code
+    [`blogmore.markdown.plain_text.markdown_to_plain_text`][blogmore.markdown.plain_text.markdown_to_plain_text].
+    Processing the complete document ensures that all Markdown constructs (fenced code
     blocks, blockquotes, etc.) are parsed in their proper context, so no raw
     Markdown artefacts bleed into the snippet even when a construct straddles
     the window boundary.
 
-    Up to ``_SNIPPET_CONTEXT_CHARS`` plain-text characters are taken on each
+    Up to `_SNIPPET_CONTEXT_CHARS` plain-text characters are taken on each
     side of the marker position, with an ellipsis (``…``) added where the
     excerpt is truncated.  The excerpt is HTML-escaped, then the marker is
     replaced directly with the plain-text link text wrapped in
@@ -98,7 +98,7 @@ def _extract_snippet(
             text is highlighted in the returned snippet.
 
     Returns:
-        An HTML-safe :class:`~markupsafe.Markup` snippet with surrounding
+        An HTML-safe [`markupsafe.Markup`][markupsafe.Markup] snippet with surrounding
         context, ellipsis markers where truncated, and the link text
         wrapped in a ``<strong>`` element.
     """
@@ -205,17 +205,17 @@ def _find_links(content: str) -> list[tuple[str, int, int, str]]:
 
 
 def _normalize_url_path(url: str) -> str:
-    """Normalise a URL path for comparison by removing ``index.html``, ``.html``, and trailing slashes.
+    """Normalise a URL path for comparison by removing `index.html`, `.html`, and trailing slashes.
 
     Produces a canonical form that can be compared regardless of whether
-    ``clean_urls`` is enabled or which URL format the author used in a link.
+    `clean_urls` is enabled or which URL format the author used in a link.
 
     Args:
         url: URL path to normalise (should start with ``/``).
 
     Returns:
-        The normalised path without a trailing slash, ``.html`` extension,
-        or ``index.html`` suffix.
+        The normalised path without a trailing slash, `.html` extension,
+        or `index.html` suffix.
     """
     url = url.rstrip("/")
     if url.endswith("/index.html"):
@@ -238,8 +238,8 @@ def _to_path(url: str, site_url: str) -> str | None:
             to strip the domain from full URLs that point back to this site.
 
     Returns:
-        The root-relative path (starting with ``/``) if the URL points to
-        this site, or ``None`` otherwise.
+        The root-relative path (starting with `/`) if the URL points to
+        this site, or `None` otherwise.
     """
     url = url.strip()
     if not url or url.startswith("#"):
@@ -276,10 +276,10 @@ def build_backlink_map(
     Scans the raw Markdown content of every post for internal links and
     records which posts link to which other posts.  Self-links are ignored.
     Links that resolve to pages (as opposed to posts) are automatically
-    excluded because the mapping is built solely from ``posts``.
+    excluded because the mapping is built solely from `posts`.
 
     The work to build this map is proportional to the total number of links
-    in all posts.  It is only called when ``with_backlinks`` is enabled in
+    in all posts.  It is only called when `with_backlinks` is enabled in
     the site configuration.
 
     Args:
@@ -289,7 +289,7 @@ def build_backlink_map(
 
     Returns:
         A dictionary mapping each post's URL to a (possibly empty) list
-        of :class:`Backlink` objects representing other posts that link
+        of [`blogmore.backlinks.Backlink`][blogmore.backlinks.Backlink] objects representing other posts that link
         to it.  Every post in *posts* has an entry in the returned dict,
         even if it has no inbound links.
     """

--- a/src/blogmore/calendar.py
+++ b/src/blogmore/calendar.py
@@ -23,7 +23,7 @@ class CalendarDay:
     date: dt.date | None
     """The calendar date for this cell.
 
-    ``None`` for padding slots that do not belong to the current month.
+    `None` for padding slots that do not belong to the current month.
     """
 
     post_count: int = 0
@@ -32,7 +32,7 @@ class CalendarDay:
     day_url: str | None = None
     """URL for the daily archive page.
 
-    Set only when ``post_count > 0``; ``None`` for padding cells and days
+    Set only when `post_count > 0`; `None` for padding cells and days
     with no posts.
     """
 
@@ -53,7 +53,7 @@ class CalendarMonth:
     month_url: str | None
     """URL linking to the monthly archive.
 
-    ``None`` when the month has no posts.
+    `None` when the month has no posts.
     """
 
     has_posts: bool
@@ -62,7 +62,7 @@ class CalendarMonth:
     weeks: list[list[CalendarDay]]
     """Calendar grid rows.
 
-    Each row contains exactly seven :class:`CalendarDay` items.  In
+    Each row contains exactly seven [`blogmore.calendar.CalendarDay`][blogmore.calendar.CalendarDay] items.  In
     reverse-chronological mode (the default) the order is Sunday-to-Monday so
     that day numbers count down left-to-right.  In forward mode the order is
     Monday-to-Sunday, matching the usual calendar convention.
@@ -79,7 +79,7 @@ class CalendarYear:
     year_url: str | None
     """URL linking to the yearly archive.
 
-    ``None`` when the year has no posts.
+    `None` when the year has no posts.
     """
 
     has_posts: bool
@@ -101,7 +101,7 @@ def build_calendar(
 ) -> list[CalendarYear]:
     """Build the calendar data structure from a list of posts.
 
-    Constructs a list of :class:`CalendarYear` objects spanning from the
+    Constructs a list of [`blogmore.calendar.CalendarYear`][blogmore.calendar.CalendarYear] objects spanning from the
     date of the first post to the date of the latest post.
 
     By default the list is in reverse chronological order (newest year
@@ -113,12 +113,12 @@ def build_calendar(
     Args:
         posts: All published posts to include in the calendar.
         page1_suffix: The URL suffix for the first pagination page (e.g.
-            ``"index.html"`` or ``""`` for clean URLs).
-        forward: When ``True``, generate the calendar in oldest-to-newest
-            order.  Defaults to ``False`` (reverse chronological).
+            `"index.html"` or `""` for clean URLs).
+        forward: When `True`, generate the calendar in oldest-to-newest
+            order.  Defaults to `False` (reverse chronological).
 
     Returns:
-        A list of :class:`CalendarYear` objects.  Returns an empty list
+        A list of [`blogmore.calendar.CalendarYear`][blogmore.calendar.CalendarYear] objects.  Returns an empty list
         when *posts* is empty or no posts have a date.
     """
     dated_posts = [p for p in posts if p.date is not None]
@@ -192,7 +192,7 @@ def build_calendar(
                 f"/{year}/{month:02d}/{page1_suffix}" if month_has_posts else None
             )
 
-            # Build the week grid.  ``monthdayscalendar`` always returns
+            # Build the week grid.  `monthdayscalendar` always returns
             # weeks in forward order (Mon first).  For reverse-chronological
             # mode, reverse both the week list and each week's day order so
             # the most recent day appears first (top-left); for forward mode,

--- a/src/blogmore/clean_url.py
+++ b/src/blogmore/clean_url.py
@@ -15,15 +15,15 @@ def make_url_clean(url: str) -> str:
     """Strip a trailing index filename from a URL path.
 
     Checks whether the final path component of *url* is exactly one of the
-    recognised index filenames (``index.html`` or ``index.htm``).  When it
+    recognised index filenames (`index.html` or `index.htm`).  When it
     is, that component is removed so that, for example,
-    ``/posts/my-post/index.html`` becomes ``/posts/my-post/``.
+    `/posts/my-post/index.html` becomes `/posts/my-post/`.
 
     Only the exact index filename is stripped.  A URL whose final component
-    merely *ends with* an index filename (e.g. ``/search-index.html``) is
-    returned unchanged, because ``search-index.html`` is not an index file
+    merely *ends with* an index filename (e.g. `/search-index.html`) is
+    returned unchanged, because `search-index.html` is not an index file
     — it is an ordinary page whose name happens to include the word
-    ``index``.
+    `index`.
 
     Args:
         url: The URL path to clean.

--- a/src/blogmore/code_styles.py
+++ b/src/blogmore/code_styles.py
@@ -27,21 +27,21 @@ def is_valid_style(style_name: str) -> bool:
         style_name: The name of the Pygments style to check.
 
     Returns:
-        ``True`` if the style name is recognised by Pygments, ``False``
+        [`True`][builtins.True] if the style name is recognised by Pygments, [`False`][builtins.False]
         otherwise.
     """
     return style_name in get_all_styles()
 
 
 def _colour_scheme_for_style(style_name: str) -> Literal["light", "dark"]:
-    """Return the CSS ``color-scheme`` value appropriate for the given Pygments style.
+    """Return the CSS `color-scheme` value appropriate for the given Pygments style.
 
     Inspects the style's background colour and calculates its perceived
-    luminance.  Styles with a dark background are classified as ``"dark"``
-    and those with a light background as ``"light"``.
+    luminance.  Styles with a dark background are classified as `"dark"`
+    and those with a light background as `"light"`.
 
-    This is used to set ``color-scheme`` on the ``.highlight`` element so
-    that the browser's ``::selection`` highlight colours and any inherited
+    This is used to set [`color-scheme`][mdn.color-scheme] on the [`.highlight`][pygments.highlight] element so
+    that the browser's [`::selection`][mdn.selection] highlight colours and any inherited
     text colours are appropriate for the Pygments style's actual background —
     regardless of the site-wide light/dark mode setting.
 
@@ -49,7 +49,7 @@ def _colour_scheme_for_style(style_name: str) -> Literal["light", "dark"]:
         style_name: A valid Pygments style name.
 
     Returns:
-        ``"dark"`` when the style has a dark background, ``"light"``
+        `"dark"` when the style has a dark background, `"light"`
         otherwise.
     """
     style = get_style_by_name(style_name)
@@ -63,18 +63,18 @@ def _colour_scheme_for_style(style_name: str) -> Literal["light", "dark"]:
 
 
 def _highlight_rules(style_name: str) -> list[str]:
-    """Extract ``.highlight`` CSS rules for the given Pygments style.
+    """Extract [`.highlight`][pygments.highlight] CSS rules for the given Pygments style.
 
-    Uses the Pygments ``HtmlFormatter`` to produce CSS and filters the output
-    to only the lines that begin with ``.highlight``, discarding all preamble
-    rules (``pre``, ``td.linenos``, etc.) which are not relevant to inline
+    Uses the Pygments [`HtmlFormatter`][pygments.HtmlFormatter] to produce CSS and filters the output
+    to only the lines that begin with [`.highlight`][pygments.highlight], discarding all preamble
+    rules ([`pre`][pygments.pre], [`td.linenos`][pygments.td.linenos], etc.) which are not relevant to inline
     code colouring.
 
     Args:
         style_name: A valid Pygments style name.
 
     Returns:
-        A list of CSS rule strings, each starting with ``.highlight``.
+        A list of CSS rule strings, each starting with [`.highlight`][pygments.highlight].
 
     Raises:
         ClassNotFound: If *style_name* is not a valid Pygments style.
@@ -85,13 +85,14 @@ def _highlight_rules(style_name: str) -> list[str]:
 
 
 def _parse_token_rules(rules: list[str]) -> dict[str, dict[str, str]]:
-    """Parse a list of raw ``.highlight`` CSS rules into a structured mapping.
+    """Parse a list of raw [`.highlight`][pygments.highlight] CSS rules into a structured mapping.
 
     Args:
-        rules: CSS rule strings as returned by :func:`_highlight_rules`.
+        rules: CSS rule strings as returned by
+            [blogmore.code_styles._highlight_rules][blogmore.code_styles._highlight_rules].
 
     Returns:
-        A dictionary mapping each CSS selector (e.g. ``".highlight .k"``) to a
+        A dictionary mapping each CSS selector (e.g. [`.highlight .k`][pygments.highlight.k]) to a
         dictionary of CSS property names to their raw values.
     """
     parsed: dict[str, dict[str, str]] = {}
@@ -112,15 +113,15 @@ def _parse_token_rules(rules: list[str]) -> dict[str, dict[str, str]]:
 
 
 def _css_var_name(selector: str, prop: str) -> str:
-    """Generate a CSS custom property name for a ``.highlight`` selector and property.
+    """Generate a CSS custom property name for a [`.highlight`][pygments.highlight] selector and property.
 
     Args:
-        selector: A CSS selector such as ``".highlight .k"`` or ``".highlight"``.
-        prop: A CSS property name such as ``"color"`` or ``"font-weight"``.
+        selector: A CSS selector such as [`.highlight .k`][pygments.highlight.k] or [`.highlight`][pygments.highlight].
+        prop: A CSS property name such as [`color`][mdn.color] or [`font-weight`][mdn.font-weight].
 
     Returns:
-        A CSS custom property name such as ``"--hl-k-color"`` or
-        ``"--hl-background"``.
+        A CSS custom property name such as [`--hl-k-color`][css.hl-k-color] or
+        [`--hl-background`][css.hl-background].
     """
     parts = selector.strip().split()
     if len(parts) > 1:
@@ -130,22 +131,22 @@ def _css_var_name(selector: str, prop: str) -> str:
 
 
 def build_code_css(light_style: str, dark_style: str) -> str:
-    """Build a complete ``code.css`` stylesheet for the given Pygments styles.
+    """Build a complete [`code.css`][blogmore.code_css] stylesheet for the given Pygments styles.
 
-    Uses CSS custom properties so that each ``.highlight`` selector rule is
+    Uses CSS custom properties so that each [`.highlight`][pygments.highlight] selector rule is
     declared only once.  Theme switching is achieved by overriding the custom
     properties in two dark-mode contexts:
 
-    * ``@media (prefers-color-scheme: dark)`` with ``:root:not([data-theme])``
+    * `@media (prefers-color-scheme: dark)` with `:root:not([data-theme])`
       — active when the operating system reports a dark preference and the
       user has not activated the theme-toggle button.
-    * ``:root[data-theme="dark"]`` — active when the theme-toggle button has
+    * `:root[data-theme="dark"]` — active when the theme-toggle button has
       explicitly selected dark mode.
 
-    The ``color-scheme`` property on ``.highlight`` is also driven by a custom
-    property (``--hl-color-scheme``), derived from the perceived background
+    The [`color-scheme`][mdn.color-scheme] property on [`.highlight`][pygments.highlight] is also driven by a custom
+    property ([`--hl-color-scheme`][css.hl-color-scheme]), derived from the perceived background
     luminance of the chosen Pygments style.  This ensures that the browser's
-    ``::selection`` colours and any inherited text colour remain appropriate
+    [`::selection`][mdn.selection] colours and any inherited text colour remain appropriate
     regardless of the site-wide light/dark mode setting.
 
     Args:
@@ -153,7 +154,7 @@ def build_code_css(light_style: str, dark_style: str) -> str:
         dark_style: Name of the Pygments style to use in dark mode.
 
     Returns:
-        A CSS string suitable for writing to ``code.css``.
+        A CSS string suitable for writing to [`code.css`][blogmore.code_css].
 
     Raises:
         ClassNotFound: If either *light_style* or *dark_style* is not a

--- a/src/blogmore/content_path.py
+++ b/src/blogmore/content_path.py
@@ -1,7 +1,7 @@
 """Shared path-resolution utilities for content output paths.
 
-This module provides the generic building blocks used by ``page_path`` and
-``post_path``.  Each content type supplies its own allowed-variable set and
+This module provides the generic building blocks used by [page_path][blogmore.page_path] and
+[post_path][blogmore.post_path].  Each content type supplies its own allowed-variable set and
 variable dict; this module handles the common validation, substitution, and
 safety checks.
 """
@@ -76,7 +76,7 @@ def validate_path_template(
 def resolve_path(variables: dict[str, str], template: str, config_key: str) -> str:
     """Resolve a path template using a pre-built variables mapping.
 
-    Substitutes *variables* into *template* via :meth:`str.format_map`,
+    Substitutes *variables* into *template* via [`str.format_map`][builtins.str.format_map],
     collapses consecutive forward slashes that may result from empty
     variable substitutions, and strips any leading slash so the result
     can safely be joined onto an output directory path.
@@ -103,10 +103,10 @@ def resolve_path(variables: dict[str, str], template: str, config_key: str) -> s
         ) from error
 
     # Collapse consecutive slashes that can arise from empty variable
-    # substitutions (e.g. an undated post using {year}/{month}).
+    # substitutions (e.g. an undated post using `{year}/{month}`).
     result = re.sub(r"/+", "/", result)
 
-    # Strip the leading slash so the result joins safely with Path('/').
+    # Strip the leading slash so the result joins safely with [`Path('/')`][pathlib.Path].
     return result.lstrip("/")
 
 
@@ -114,7 +114,7 @@ def safe_output_path(output_dir: Path, relative: str, config_key: str) -> Path:
     """Join *relative* onto *output_dir* and verify the result stays inside it.
 
     Prevents accidental path-traversal writes that could occur if a
-    user-supplied template contains ``..`` segments.
+    user-supplied template contains `..` segments.
 
     Args:
         output_dir: The root output directory for the generated site.
@@ -133,7 +133,7 @@ def safe_output_path(output_dir: Path, relative: str, config_key: str) -> Path:
     output_resolved = output_dir.resolve()
 
     if not candidate.is_relative_to(output_resolved):
-        # Derive a human-readable label: "page_path" → "page path".
+        # Derive a human-readable label: `page_path` → `page path`.
         label = config_key.replace("_", " ")
         raise ValueError(
             f"The resolved {label} '{relative}' escapes the output directory. "

--- a/src/blogmore/fontawesome.py
+++ b/src/blogmore/fontawesome.py
@@ -55,8 +55,8 @@ class FontAwesomeOptimizer:
 
     Fetches the official FontAwesome icon metadata from GitHub to obtain the
     Unicode codepoints for each requested icon, then assembles a minimal CSS
-    file containing only the ``@font-face`` declaration, the base
-    ``.fa-brands`` / ``.fab`` rules, and the individual icon definitions.
+    file containing only the `@font-face` declaration, the base
+    `.fa-brands` / `.fab` rules, and the individual icon definitions.
 
     Fonts themselves remain on the CDN so browsers can cache them across
     sites.
@@ -76,7 +76,7 @@ class FontAwesomeOptimizer:
 
         Returns:
             Dictionary mapping icon name to its metadata (including the
-            ``unicode`` codepoint field).
+            `unicode` codepoint field).
 
         Raises:
             urllib.error.URLError: If the metadata cannot be fetched from
@@ -91,11 +91,11 @@ class FontAwesomeOptimizer:
 
         Args:
             metadata: FontAwesome icon metadata as returned by
-                :meth:`fetch_icon_metadata`.
+                `blogmore.fontawesome.FontAwesomeOptimizer.fetch_icon_metadata`.
 
         Returns:
-            CSS string containing the ``@font-face`` declaration, base class
-            rules, and one ``::before`` rule per requested icon found in the
+            CSS string containing the `@font-face` declaration, base class
+            rules, and one `::before` rule per requested icon found in the
             metadata.
         """
         woff2_url = f"{FONTAWESOME_CDN_WEBFONTS_BASE}/fa-brands-400.woff2"
@@ -139,14 +139,14 @@ class FontAwesomeOptimizer:
     def generate(self, output_dir: Path) -> bool:
         """Fetch metadata, build CSS, and write it to the output directory.
 
-        The CSS file is written to ``output_dir/static/fontawesome.css``.
+        The CSS file is written to `output_dir/static/fontawesome.css`.
 
         Args:
             output_dir: Root output directory of the generated site.
 
         Returns:
-            ``True`` if the optimized CSS file was written successfully,
-            ``False`` if the metadata could not be fetched (caller should
+            `True` if the optimized CSS file was written successfully,
+            `False` if the metadata could not be fetched (caller should
             fall back to the CDN stylesheet).
         """
         try:

--- a/src/blogmore/generator.py
+++ b/src/blogmore/generator.py
@@ -124,7 +124,7 @@ class SiteGenerator:
 
         Args:
             site_config: Configuration for the site to be generated.  The
-                ``content_dir`` field must not be ``None``.
+                [`content_dir`][blogmore.site_config.SiteConfig.content_dir] field must not be `None`.
         """
         if site_config.content_dir is None:
             raise ValueError(

--- a/src/blogmore/graph.py
+++ b/src/blogmore/graph.py
@@ -2,12 +2,12 @@
 
 Builds a force-directed graph data structure from posts, connecting them
 via internal links, shared tags, and shared categories.  This module is
-only consulted when ``with_graph`` is enabled in the site configuration.
+only consulted when `with_graph` is enabled in the site configuration.
 When the feature is disabled none of these functions are called, so users
 pay no cost for a feature they do not use.
 
 Link scanning and URL normalisation are delegated to the shared utilities
-in :mod:`blogmore.backlinks` to avoid code duplication.
+in [`blogmore.backlinks`][blogmore.backlinks] to avoid code duplication.
 """
 
 ##############################################################################
@@ -27,13 +27,13 @@ class GraphData:
     """Data for the post-relationship force-directed graph.
 
     Attributes:
-        nodes: List of node dicts.  Each node always has ``id``, ``label``,
-            ``type``, and ``url`` keys.  Post nodes additionally carry
-            ``date`` (ISO date string or ``None``), ``description`` (str),
-            and ``cover`` (URL string or ``None``).  Tag and category nodes
-            additionally carry ``post_count`` (int).
-        links: List of edge dicts, each with ``source`` and ``target`` keys
-            corresponding to node ``id`` values.
+        nodes: List of node dicts.  Each node always has `id`, `label`,
+            `type`, and `url` keys.  Post nodes additionally carry
+            `date` (ISO date string or `None`), `description` (str),
+            and `cover` (URL string or `None`).  Tag and category nodes
+            additionally carry `post_count` (int).
+        links: List of edge dicts, each with `source` and `target` keys
+            corresponding to node `id` values.
     """
 
     nodes: list[dict[str, Any]] = field(default_factory=list)
@@ -76,7 +76,7 @@ def build_graph_data(
     * Post -> category relationships (one edge per post that has a category).
     * Post -> post internal links (one edge per unique directed link found in
       Markdown content, discovered by scanning inline and reference-style
-      Markdown links via :func:`~blogmore.backlinks._find_links`).
+      Markdown links via [`blogmore.backlinks._find_links`][blogmore.backlinks._find_links]).
 
     Args:
         posts: All published posts for the site.
@@ -89,7 +89,7 @@ def build_graph_data(
             scanning post content for internal links.  May be empty.
 
     Returns:
-        A :class:`GraphData` instance populated with nodes and links.
+        A [`blogmore.graph.GraphData`][blogmore.graph.GraphData] instance populated with nodes and links.
     """
     graph = GraphData()
 

--- a/src/blogmore/markdown/first_paragraph.py
+++ b/src/blogmore/markdown/first_paragraph.py
@@ -22,11 +22,11 @@ def _make_extraction_markdown() -> markdown.Markdown:
 
     Includes all BlogMore custom extensions and the standard extensions needed
     to correctly identify paragraph boundaries.  Intentionally omits
-    presentation-only extensions such as ``codehilite`` and ``toc`` that are
-    not required for plain-text extraction.
+    presentation-only extensions such as [`codehilite`][markdown.extensions.codehilite]
+    and [`toc`][markdown.extensions.toc] that are not required for plain-text extraction.
 
     Returns:
-        A fresh, configured :class:`markdown.Markdown` instance.
+        A fresh, configured ``markdown.Markdown`` instance.
     """
     return markdown.Markdown(
         extensions=[
@@ -41,8 +41,8 @@ def _make_extraction_markdown() -> markdown.Markdown:
 class _FirstParagraphExtractor(HTMLParser):
     """HTML parser that extracts plain text from the first non-image-only paragraph.
 
-    Only top-level ``<p>`` elements are considered; paragraphs nested inside
-    block-level containers such as admonition ``<div>`` elements, blockquotes,
+    Only top-level `<p>` elements are considered; paragraphs nested inside
+    block-level containers such as admonition `<div>` elements, blockquotes,
     or list items are skipped.  A paragraph that consists entirely of images
     (no text data) is also skipped so that posts that open with a banner image
     return the following descriptive paragraph instead.
@@ -77,18 +77,18 @@ class _FirstParagraphExtractor(HTMLParser):
 
         Sets up all tracking state used during parsing:
 
-        * ``_block_depth`` — current nesting level inside block-level container
-          elements (``<div>``, ``<blockquote>``, ``<ul>``, etc.).  Any ``<p>``
+        * `_block_depth` — current nesting level inside block-level container
+          elements (`<div>`, `<blockquote>`, `<ul>`, etc.).  Any `<p>`
           encountered while this is non-zero is nested and therefore skipped.
-        * ``_in_paragraph`` — whether the parser is currently inside a
-          candidate top-level ``<p>`` element.
-        * ``_chunks`` — raw character-data fragments collected from the current
+        * `_in_paragraph` — whether the parser is currently inside a
+          candidate top-level `<p>` element.
+        * `_chunks` — raw character-data fragments collected from the current
           paragraph, joined and normalised when the paragraph ends.
-        * ``_has_text`` — set to ``True`` as soon as non-whitespace data is
+        * `_has_text` — set to `True` as soon as non-whitespace data is
           seen inside the current paragraph; keeps image-only paragraphs from
           being returned.
-        * ``_result`` — the accepted plain-text paragraph (empty until found).
-        * ``_done`` — short-circuit flag; once ``True`` all further events are
+        * `_result` — the accepted plain-text paragraph (empty until found).
+        * `_done` — short-circuit flag; once `True` all further events are
           ignored.
         """
         super().__init__(convert_charrefs=True)
@@ -104,7 +104,7 @@ class _FirstParagraphExtractor(HTMLParser):
 
         Args:
             tag: The lowercase tag name.
-            attrs: List of ``(attribute-name, value)`` pairs for the tag.
+            attrs: List of (`attribute-name`, value) pairs for the tag.
         """
         if self._done:
             return

--- a/src/blogmore/markdown/plain_text.py
+++ b/src/blogmore/markdown/plain_text.py
@@ -1,13 +1,13 @@
 """Markdown to plain text conversion utility.
 
-Provides :func:`markdown_to_plain_text` — the canonical way to convert a
+Provides `blogmore.markdown.plain_text.markdown_to_plain_text` — the canonical way to convert a
 Markdown string to clean, whitespace-collapsed plain text within BlogMore.
 It runs the input through the Python-Markdown library so that all block
 structures (fenced code, blockquotes, tables, admonitions, etc.) are handled
 correctly before HTML tags are stripped.
 
 This module is also the single source of truth for BlogMore's custom Markdown
-extension set via :func:`create_custom_extensions`, which is consumed by the
+extension set via `blogmore.markdown.plain_text.create_custom_extensions`, which is consumed by the
 full site parser, the first-paragraph extractor, and any other context that
 needs to render or strip BlogMore-flavoured Markdown.
 """
@@ -60,11 +60,11 @@ def _make_markdown_instance() -> markdown.Markdown:
 
     Includes all BlogMore custom extensions and the standard extensions
     needed to correctly parse all block structures.  Intentionally omits
-    presentation-only extensions (``codehilite``, ``toc``) that are not
+    presentation-only extensions (`codehilite`, `toc`) that are not
     required for text extraction.
 
     Returns:
-        A fresh, configured :class:`markdown.Markdown` instance.
+        A fresh, configured `markdown.Markdown` instance.
     """
     return markdown.Markdown(
         extensions=[
@@ -112,8 +112,8 @@ def markdown_to_plain_text(text: str) -> str:
     """Convert a Markdown string to clean plain text.
 
     Runs the input through Python-Markdown (with all BlogMore extensions and
-    common block-level extensions such as ``fenced_code``, ``tables``, and
-    ``footnotes``) to produce HTML, then strips all HTML tags and collapses
+    common block-level extensions such as `fenced_code`, `tables`, and
+    `footnotes`) to produce HTML, then strips all HTML tags and collapses
     whitespace.  This correctly handles all Markdown block structures
     including fenced code blocks, blockquotes, admonitions, and tables —
     none of these leave raw Markdown syntax characters in the result.

--- a/src/blogmore/markdown/strikethrough.py
+++ b/src/blogmore/markdown/strikethrough.py
@@ -22,7 +22,7 @@ class StrikethroughInlineProcessor(InlineProcessor):
 
         Returns:
             A tuple of the ``<del>`` element and the start and end positions
-            of the match within ``data``.
+            of the match within `data`.
         """
         element = etree.Element("del")
         element.text = m.group(1)

--- a/src/blogmore/pagination_path.py
+++ b/src/blogmore/pagination_path.py
@@ -23,9 +23,9 @@ def validate_page_1_path_template(template: str) -> None:
     """Validate a page_1_path format string.
 
     Checks that the template string is well-formed and only references
-    variables from the allowed set.  The ``{page}`` placeholder is
-    allowed but not required in ``page_1_path`` (since the default
-    ``index.html`` does not use it).
+    variables from the allowed set.  The `{page}` placeholder is
+    allowed but not required in `page_1_path` (since the default
+    `index.html` does not use it).
 
     Args:
         template: The page_1_path format string to validate.

--- a/src/blogmore/parser.py
+++ b/src/blogmore/parser.py
@@ -36,9 +36,9 @@ class _LangAwareHtmlFormatter(HtmlFormatter[str]):
     """Pygments HTML formatter that exposes the detected language via a data attribute.
 
     The codehilite Markdown extension passes the fenced code block language as
-    ``lang_str`` (e.g. ``language-python``) when constructing the formatter.
-    This subclass captures that value and writes it as a ``data-lang`` attribute
-    on the wrapper ``<div>``, making it available to JavaScript without any
+    `lang_str` (e.g. `language-python`) when constructing the formatter.
+    This subclass captures that value and writes it as a `data-lang` attribute
+    on the wrapper `<div>`, making it available to JavaScript without any
     additional post-processing.
     """
 
@@ -47,10 +47,10 @@ class _LangAwareHtmlFormatter(HtmlFormatter[str]):
 
         Args:
             lang_str: The language string passed by codehilite, typically in the
-                form ``language-<name>`` (e.g. ``language-python``).  An empty
+                form `language-<name>` (e.g. `language-python`).  An empty
                 string means no language was specified.
             **kwargs: Remaining keyword arguments forwarded to
-                :class:`pygments.formatters.HtmlFormatter`.
+                `pygments.formatters.HtmlFormatter`.
         """
         super().__init__(**kwargs)
         self._lang_name = lang_str.removeprefix(_LANG_PREFIX) if lang_str else ""
@@ -58,16 +58,16 @@ class _LangAwareHtmlFormatter(HtmlFormatter[str]):
     def _wrap_div(
         self, inner: Generator[tuple[int, str], None, None]
     ) -> Generator[tuple[int, str], None, None]:
-        """Wrap the highlighted code in a ``<div>`` element.
+        """Wrap the highlighted code in a `<div>` element.
 
-        Extends the parent implementation by adding a ``data-lang`` attribute
+        Extends the parent implementation by adding a `data-lang` attribute
         when a language name is available.
 
         Args:
-            inner: Generator of ``(token_type, value)`` tuples from the parent.
+            inner: Generator of `(token_type, value)` tuples from the parent.
 
         Yields:
-            ``(token_type, value)`` tuples forming the wrapped HTML.
+            `(token_type, value)` tuples forming the wrapped HTML.
         """
         style_parts: list[str] = []
         if (
@@ -144,13 +144,13 @@ class Post:
     def url(self) -> str:
         """Generate the URL path for the post.
 
-        If the generator has resolved a custom URL via the ``post_path``
-        configuration option it will be stored in ``url_path`` and returned
+        If the generator has resolved a custom URL via the `post_path`
+        configuration option it will be stored in `url_path` and returned
         directly.  Otherwise the URL is derived from the post date and slug
-        using the default ``/{year}/{month}/{day}/{slug}.html`` scheme.
+        using the default `/{year}/{month}/{day}/{slug}.html` scheme.
 
         Returns:
-            The URL path for the post, always beginning with ``/``.
+            The URL path for the post, always beginning with `/`.
         """
         if self.url_path is not None:
             return self.url_path
@@ -212,7 +212,7 @@ class Post:
     def modified_date(self) -> dt.datetime | None:
         """Get the modified date as a datetime object.
 
-        Parses the ``modified`` field from metadata into a proper datetime,
+        Parses the `modified` field from metadata into a proper datetime,
         handling datetime objects returned by the YAML parser as well as raw
         strings in common date formats.
 
@@ -280,13 +280,13 @@ class Page:
     def url(self) -> str:
         """Generate the URL path for the page.
 
-        If the generator has resolved a custom URL via the ``page_path``
-        configuration option it will be stored in ``url_path`` and returned
+        If the generator has resolved a custom URL via the `page_path`
+        configuration option it will be stored in `url_path` and returned
         directly.  Otherwise the URL is derived from the page slug using the
-        default ``/{slug}.html`` scheme.
+        default `/{slug}.html` scheme.
 
         Returns:
-            The URL path for the page, always beginning with ``/``.
+            The URL path for the page, always beginning with `/`.
         """
         if self.url_path is not None:
             return self.url_path
@@ -565,8 +565,8 @@ class PostParser:
     def parse_pages_directory(self, directory: Path) -> list[Page]:
         """Parse all markdown files in a pages directory.
 
-        The special file ``404.md`` is excluded from the returned list; use
-        :meth:`parse_404_page` to obtain it separately.
+        The special file `404.md` is excluded from the returned list; use
+        `blogmore.parser.parse_404_page` to obtain it separately.
 
         Args:
             directory: Directory containing page markdown files
@@ -596,11 +596,11 @@ class PostParser:
         """Parse the optional custom 404 page from a pages directory.
 
         Args:
-            directory: Directory that may contain a ``404.md`` file
+            directory: Directory that may contain a `404.md` file
 
         Returns:
-            A Page object if ``404.md`` exists and parses successfully,
-            otherwise ``None``
+            A Page object if `404.md` exists and parses successfully,
+            otherwise `None`
         """
         path = directory / CUSTOM_404_MARKDOWN
         if not path.exists():

--- a/src/blogmore/renderer.py
+++ b/src/blogmore/renderer.py
@@ -78,7 +78,7 @@ class TemplateRenderer:
         """Format a datetime object as HTML with archive links.
 
         The date portion is rendered as
-        ``<a href="/{year}/">{year}</a>-<a href="/{year}/{mm}/">{mm}</a>-<a href="/{year}/{mm}/{dd}/">{dd}</a>``
+        `<a href="/{year}/">{year}</a>-<a href="/{year}/{mm}/">{mm}</a>-<a href="/{year}/{mm}/{dd}/">{dd}</a>`
         so each component links to the corresponding archive page.
 
         Args:
@@ -395,8 +395,8 @@ class TemplateRenderer:
 
         Args:
             **context: Context variables to pass to the template.  Should
-                include a ``stats`` key containing a
-                :class:`~blogmore.stats.BlogStats` instance.
+                include a `stats` key containing a
+                `blogmore.stats.BlogStats` instance.
 
         Returns:
             Rendered HTML string.
@@ -409,8 +409,8 @@ class TemplateRenderer:
 
         Args:
             **context: Context variables to pass to the template.  Should
-                include a ``calendar_years`` key containing a list of
-                :class:`~blogmore.calendar.CalendarYear` instances.
+                include a `calendar_years` key containing a list of
+                `blogmore.calendar.CalendarYear` instances.
 
         Returns:
             Rendered HTML string.
@@ -423,9 +423,9 @@ class TemplateRenderer:
 
         Args:
             **context: Context variables to pass to the template.  Should
-                include a ``graph_data_json`` key containing the serialised
+                include a `graph_data_json` key containing the serialised
                 JSON string produced by
-                :meth:`~blogmore.graph.GraphData.to_json`.
+                `blogmore.graph.GraphData.to_json`.
 
         Returns:
             Rendered HTML string.

--- a/src/blogmore/search.py
+++ b/src/blogmore/search.py
@@ -53,9 +53,9 @@ def build_search_index(posts: list[Post]) -> list[dict[str, Any]]:
 def write_search_index(posts: list[Post], output_dir: Path) -> None:
     """Write the search index JSON file to the output directory.
 
-    The file is written as ``search_index.json`` at the root of the
+    The file is written as `search_index.json` at the root of the
     output directory.  It is a JSON array of objects as produced by
-    :func:`build_search_index`.
+    `blogmore.search.build_search_index`.
 
     Args:
         posts: List of posts to index.

--- a/src/blogmore/server.py
+++ b/src/blogmore/server.py
@@ -52,7 +52,7 @@ class QuietHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     Uses HTTP/1.1 to enable keep-alive connections, which significantly improves
     performance in browsers like Safari that make many parallel requests.
 
-    When a ``404.html`` file exists in the served directory it is returned as
+    When a `404.html` file exists in the served directory it is returned as
     the response body for any 404 error, mirroring the behaviour of services
     such as GitHub Pages.
     """
@@ -305,8 +305,8 @@ def serve_site(
 
     Args:
         site_config: Site configuration holding all generation parameters.
-            When ``site_config.content_dir`` is not ``None`` the site will be
-            (re-)generated before serving.  ``site_config.include_drafts``
+            When `site_config.content_dir` is not `None` the site will be
+            (re-)generated before serving.  `site_config.include_drafts`
             controls whether draft posts are included.
         port: Port to serve on (default: 8000)
         watch: Whether to watch for changes and regenerate (default: True)

--- a/src/blogmore/site_config.py
+++ b/src/blogmore/site_config.py
@@ -56,13 +56,13 @@ class SiteConfig:
     content_dir: Path | None = None
     """Directory containing Markdown posts.
 
-    May be ``None`` when serving an already-generated site without rebuilding.
+    May be `None` when serving an already-generated site without rebuilding.
     """
 
     templates_dir: Path | None = None
     """Optional directory containing custom Jinja2 templates.
 
-    When ``None`` the bundled templates are used.
+    When `None` the bundled templates are used.
     """
 
     site_title: str = "My Blog"
@@ -78,7 +78,7 @@ class SiteConfig:
     """Default keywords used in metadata for pages without their own keywords."""
 
     site_url: str = ""
-    """Base URL of the site (e.g. ``https://example.com``)."""
+    """Base URL of the site (e.g. `https://example.com`)."""
 
     posts_per_feed: int = 20
     """Maximum number of posts to include in RSS/Atom feeds."""
@@ -90,13 +90,13 @@ class SiteConfig:
     """Default author name for posts that lack an author in their frontmatter."""
 
     sidebar_config: dict[str, Any] = field(default_factory=dict)
-    """Sidebar configuration (``site_logo``, ``links``, ``socials``, etc.)."""
+    """Sidebar configuration (`site_logo`, `links`, `socials`, etc.)."""
 
     clean_first: bool = False
     """Whether to remove the output directory before generating."""
 
     icon_source: str | None = None
-    """Optional source icon filename in the ``extras/`` directory."""
+    """Optional source icon filename in the `extras/` directory."""
 
     with_search: bool = False
     """Whether to generate a search index and search page."""
@@ -133,11 +133,11 @@ class SiteConfig:
     running left to right in normal calendar order (Monday first).
 
     This is a **configuration file only** option — it cannot be set on the
-    command line.  Only meaningful when :attr:`with_calendar` is ``True``.
+    command line.  Only meaningful when ``with_calendar`` is ``True``.
     """
 
     minify_css: bool = False
-    """Whether to minify the CSS, writing it as ``styles.min.css``."""
+    """Whether to minify the CSS, writing it as `styles.min.css`."""
 
     minify_js: bool = False
     """Whether to minify the JavaScript output files."""
@@ -173,7 +173,7 @@ class SiteConfig:
 
     Overrides the default "References & mentions" heading rendered inside the
     ``backlinks`` template block on individual post pages.  Only meaningful
-    when :attr:`with_backlinks` is ``True``.
+    when ``with_backlinks`` is ``True``.
 
     This is a **configuration file only** option — it cannot be set on the
     command line.  Defaults to ``"References & mentions"``.
@@ -326,7 +326,7 @@ class SiteConfig:
     """Whether to generate a post-relationship force-directed graph page.
 
     When ``True`` the generator produces a graph page (at the path configured
-    by :attr:`graph_path`) that visualises the relationships between posts,
+    by ``graph_path``) that visualises the relationships between posts,
     tags, and categories using the ``force-graph`` library.  A **Graph** link
     is automatically added to the navigation bar between **Calendar** and
     **RSS**.
@@ -431,7 +431,7 @@ class SiteConfig:
     invite_comments: bool = False
     """Whether to show a comment invitation section on individual post pages.
 
-    When ``True`` and :attr:`invite_comments_to` is also configured, every
+    When ``True`` and ``invite_comments_to`` is also configured, every
     post will display a comment invitation section towards the bottom of the
     page, after the next/previous navigation buttons and before any
     "References & mentions" section.
@@ -446,9 +446,9 @@ class SiteConfig:
     invite_comments_to: str | None = None
     """Template string for the comment invitation email address.
 
-    When :attr:`invite_comments` is ``True`` and this option is set, the
+    When ``invite_comments`` is ``True`` and this option is set, the
     template is expanded for each post using the same variable placeholders
-    that are available for :attr:`post_path` (``{slug}``, ``{year}``,
+    that are available for ``post_path`` (``{slug}``, ``{year}``,
     ``{month}``, ``{day}``, ``{hour}``, ``{minute}``, ``{second}``,
     ``{category}``, ``{author}``).  The resulting string is used as the
     ``mailto:`` address in the comment invitation link.

--- a/src/blogmore/sitemap.py
+++ b/src/blogmore/sitemap.py
@@ -36,17 +36,17 @@ def collect_sitemap_urls(
 ) -> list[str]:
     """Collect all page URLs for the sitemap.
 
-    Walks the output directory collecting every ``.html`` file, excluding
+    Walks the output directory collecting every `.html` file, excluding
     the search page, the custom 404 page, and any paths in
-    ``extra_excluded_paths``.  Each file path is converted to an absolute
-    URL using ``site_url`` as the base.  If ``site_url`` is empty, the
-    fallback ``https://example.com`` is used.
+    `extra_excluded_paths`.  Each file path is converted to an absolute
+    URL using `site_url` as the base.  If `site_url` is empty, the
+    fallback `https://example.com` is used.
 
-    When *clean_urls* is ``True``, any URL that ends with ``/index.html``
-    has the ``index.html`` portion removed so the URL ends with a trailing
+    When *clean_urls* is `True`, any URL that ends with `/index.html`
+    has the `index.html` portion removed so the URL ends with a trailing
     slash instead.
 
-    Any root-relative paths in ``extra_urls`` (e.g. ``"/some/path/"``) are
+    Any root-relative paths in `extra_urls` (e.g. `"/some/path/"`) are
     resolved against the base URL and appended to the collected URLs.
 
     Args:

--- a/src/blogmore/stats.py
+++ b/src/blogmore/stats.py
@@ -47,10 +47,10 @@ class StreakChartVariant:
         first_date: First date of the window (first day of the oldest month).
         last_date: Last date of the window (today when the variant was built).
         month_label_positions: Month labels paired with their 1-based week
-            column index in :attr:`weeks`.  Each entry is ``(label, col)``,
-            e.g. ``("Apr", 1)``.
+            column index in `weeks`.  Each entry is (`label`, col),
+            e.g. (`"Apr"`, 1).
         weeks: Week columns, oldest first.  Each column is a list of exactly
-            7 entries ordered Sunday-first.  An entry is ``None`` when the
+            7 entries ordered Sunday-first.  An entry is `None` when the
             slot falls outside the window.
     """
 
@@ -145,9 +145,9 @@ class BlogStats:
 
     All histogram counts are fixed-length lists indexed from zero:
 
-    * ``posts_per_hour`` — 24 elements, index 0 = midnight hour.
-    * ``posts_per_weekday`` — 7 elements, index 0 = Monday.
-    * ``posts_per_month`` — 12 elements, index 0 = January.
+    * [`posts_per_hour`][blogmore.stats.BlogStats.posts_per_hour] — 24 elements, index 0 = midnight hour.
+    * [`posts_per_weekday`][blogmore.stats.BlogStats.posts_per_weekday] — 7 elements, index 0 = Monday.
+    * [`posts_per_month`][blogmore.stats.BlogStats.posts_per_month] — 12 elements, index 0 = January.
 
     Posts without a date are excluded from date-based statistics.
     Posts without any content contribute zero to word-count statistics.
@@ -230,7 +230,7 @@ class BlogStats:
 
     Only posts with at least one backlink are included.  Sorted by count
     descending.  Populated only when the backlink map is supplied to
-    :func:`compute_blog_stats`.
+    ``[blogmore.stats.compute_blog_stats][blogmore.stats.compute_blog_stats].
     """
 
     posts_in_last_year: int = 0
@@ -254,11 +254,11 @@ class BlogStats:
 
     @property
     def blog_span_days(self) -> int | None:
-        """Return the total span of the blog in days, or ``None`` if fewer than two dated posts exist.
+        """Return the total span of the blog in days, or [`None`][builtins.None] if fewer than two dated posts exist.
 
         Returns:
             Number of days between the earliest and latest post dates, or
-            ``None`` when fewer than two dated posts exist.
+            ``[`None`][builtins.None] when fewer than two dated posts exist.
         """
         if self.earliest_post_date is None or self.latest_post_date is None:
             return None
@@ -269,7 +269,7 @@ class BlogStats:
 def _extract_external_links(html_content: str, site_url: str) -> list[str]:
     """Extract all external URLs referenced in an HTML fragment.
 
-    Finds every ``href`` attribute value inside anchor tags and filters out
+    Finds every `href` attribute value inside anchor tags and filters out
     URLs that point to the same site (as determined by *site_url*).
 
     Args:
@@ -318,7 +318,7 @@ def _compute_streak_variant(
             the current (partial) month.
 
     Returns:
-        A :class:`StreakChartVariant` for the requested window.
+        A [blogmore.stats.StreakChartVariant][blogmore.stats.StreakChartVariant] for the requested window.
     """
     # 1st of the month (num_months - 1) months before today.
     start_month = today.month - (num_months - 1)
@@ -401,7 +401,7 @@ def _compute_longest_streaks(
         min_days: Minimum streak length (in days) to include.
 
     Returns:
-        A list of up to *max_streaks* :class:`PostingStreak` objects sorted
+        A list of up to *max_streaks* [blogmore.stats.PostingStreak][blogmore.stats.PostingStreak] objects sorted
         by descending length, then descending post count, then descending
         start date.
     """
@@ -467,13 +467,13 @@ def compute_blog_stats(
         site_url: The configured base URL of the blog site.  Used to
             distinguish internal from external links.  May be empty.
         backlink_map: Optional mapping from post URL to list of
-            :class:`~blogmore.backlinks.Backlink` objects, as returned by
-            :func:`~blogmore.backlinks.build_backlink_map`.  When provided,
-            :attr:`BlogStats.top_internal_links` is populated with the top 20
+            [`blogmore.backlinks.Backlink`][blogmore.backlinks.Backlink] objects, as returned by
+            [`blogmore.backlinks.build_backlink_map`][blogmore.backlinks.build_backlink_map].  When provided,
+            [`BlogStats.top_internal_links`][blogmore.stats.BlogStats.top_internal_links] is populated with the top 20
             posts sorted by incoming link count descending.
 
     Returns:
-        A :class:`BlogStats` instance populated from the given posts.
+        A [blogmore.stats.BlogStats][blogmore.stats.BlogStats] instance populated from the given posts.
     """
     stats = BlogStats()
 

--- a/src/blogmore/utils.py
+++ b/src/blogmore/utils.py
@@ -73,9 +73,9 @@ def calculate_reading_time(content: str, words_per_minute: int = 200) -> int:
 def make_urls_absolute(html_content: str, base_url: str) -> str:
     """Rewrite root-relative URLs in HTML content to absolute URLs.
 
-    Converts ``src`` and ``href`` attributes whose values begin with ``/``
+    Converts `src` and `href` attributes whose values begin with `/`
     to full absolute URLs by prepending *base_url*.  Attributes that already
-    contain an absolute URL (i.e. they include a scheme such as ``https://``)
+    contain an absolute URL (i.e. they include a scheme such as `https://`)
     are left unchanged.
 
     Args:
@@ -85,7 +85,7 @@ def make_urls_absolute(html_content: str, base_url: str) -> str:
             start with ``/``.
 
     Returns:
-        HTML string with root-relative ``src``/``href`` values replaced by
+        HTML string with root-relative `src`/`href` values replaced by
         absolute URLs.
 
     Examples:


### PR DESCRIPTION
Tidy up the docstrings so that mkdocstrings-style code markup and cross-references are used.