### PR TITLE
Clean up the type checking of the generator (Copilot/Claude edition)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ generator into focused modules and mixin classes:
 |---|---|
 | `generator/constants.py` | Filename constants, `TAG_DIR`, `CATEGORY_DIR`, `_PAGE_SPECIFIC_CSS` |
 | `generator/utils.py` | `minified_filename`, `paginate_posts` |
+| `generator/_base.py` | `GeneratorBase` — shared ABC; declares all cross-mixin method stubs and instance attributes |
 | `generator/_grouping.py` | `GroupingMixin` — post grouping by tag/category; word-cloud font-size interpolation |
 | `generator/_context.py` | `ContextMixin` — global template context, asset URL helpers, cache-busting |
 | `generator/_paths.py` | `PathsMixin` — pagination paths, canonical URLs, output path resolution, sidebar filtering |
@@ -48,14 +49,16 @@ generator into focused modules and mixin classes:
 `SiteGenerator` composes all mixin classes:
 
 ```
-MinifyMixin
-  └── AssetsMixin          (adds icons, file copying)
-
-DateArchivesMixin
-  └── ListingMixin         (adds tag/category listings)
-
-OptionalPagesMixin
-  └── PagesMixin           (adds core post/page/index/archive)
+GeneratorBase(ABC)          (shared stubs + attribute declarations)
+  ├── ContextMixin
+  ├── GroupingMixin
+  ├── MinifyMixin
+  │     └── AssetsMixin      (adds icons, file copying)
+  ├── PathsMixin
+  ├── DateArchivesMixin
+  │     └── ListingMixin     (adds tag/category listings)
+  └── OptionalPagesMixin
+        └── PagesMixin       (adds core post/page/index/archive)
 
 SiteGenerator(
     AssetsMixin, ContextMixin, GroupingMixin,

--- a/src/blogmore/generator/__init__.py
+++ b/src/blogmore/generator/__init__.py
@@ -5,10 +5,12 @@ directly from the ``blogmore.generator`` module, ensuring full backward
 compatibility for existing imports.
 """
 
+from blogmore.generator._base import GeneratorBase
 from blogmore.generator.site import SiteGenerator
 from blogmore.generator.utils import minified_filename, paginate_posts
 
 __all__ = [
+    "GeneratorBase",
     "SiteGenerator",
     "minified_filename",
     "paginate_posts",

--- a/src/blogmore/generator/_assets.py
+++ b/src/blogmore/generator/_assets.py
@@ -24,26 +24,14 @@ from blogmore.generator.constants import (
     THEME_JS_FILENAME,
 )
 from blogmore.icons import IconGenerator, detect_source_icon
-from blogmore.renderer import TemplateRenderer
-from blogmore.site_config import SiteConfig
 
 
 class AssetsMixin(MinifyMixin):
     """Mixin that manages icon generation and static file copying.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `_fontawesome_css_url` (`str`)
-    - `_extras_html_paths` (`frozenset[str]`)
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    _fontawesome_css_url: str
-    _extras_html_paths: frozenset[str]
 
     @property
     def _content_dir(self) -> Path:

--- a/src/blogmore/generator/_base.py
+++ b/src/blogmore/generator/_base.py
@@ -1,0 +1,177 @@
+"""Abstract base class shared by all [`SiteGenerator`][blogmore.generator.site.SiteGenerator] mixins.
+
+[`GeneratorBase`][blogmore.generator._base.GeneratorBase] declares every
+instance attribute and every method that is called *across* mixin boundaries
+so that mypy can type-check all mixin code without `# type: ignore` comments.
+
+Every mixin whose class hierarchy does not already include another mixin that
+inherits from this base must inherit from it directly.  At runtime the MRO of
+[`SiteGenerator`][blogmore.generator.site.SiteGenerator] ensures that all
+abstract stubs are satisfied by the concrete implementations scattered across
+the various mixin modules.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from blogmore.parser import Post
+from blogmore.renderer import TemplateRenderer
+from blogmore.site_config import SiteConfig
+
+
+class GeneratorBase(ABC):
+    """Shared abstract base for all `SiteGenerator` mixin classes.
+
+    Declares the complete set of instance attributes and cross-mixin method
+    stubs that the mixin layer depends on.  Inheriting from this class gives
+    mypy full visibility of the composed interface without requiring any
+    `# type: ignore` pragmas in mixin code.
+
+    The class is intentionally abstract: it is never instantiated on its own.
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator] is the only
+    concrete subclass and it satisfies every abstract stub by composing all
+    mixin implementations.
+    """
+
+    # ------------------------------------------------------------------
+    # Instance attributes
+    # These are declared here once so that every mixin can reference them
+    # on `self` without repeating the annotations in each module.
+    # ------------------------------------------------------------------
+
+    site_config: SiteConfig
+    renderer: TemplateRenderer
+    _fontawesome_css_url: str
+    _cache_bust_token: str
+    _extras_html_paths: frozenset[str]
+    POSTS_PER_PAGE_INDEX: int
+    POSTS_PER_PAGE_TAG: int
+    POSTS_PER_PAGE_CATEGORY: int
+    POSTS_PER_PAGE_ARCHIVE: int
+
+    # ------------------------------------------------------------------
+    # Cross-mixin method stubs
+    # Each stub is declared here and implemented in exactly one mixin.
+    # Declaring them as @abstractmethod means SiteGenerator cannot be
+    # instantiated if a mixin is accidentally removed from its bases.
+    # ------------------------------------------------------------------
+
+    # -- AssetsMixin (called by ContextMixin) --------------------------
+
+    @abstractmethod
+    def _detect_favicon(self) -> str | None:
+        """Return the URL path of the site favicon, or ``None`` if absent."""
+
+    @abstractmethod
+    def _detect_generated_icons(self) -> bool:
+        """Return ``True`` when platform icons have been generated."""
+
+    # -- ContextMixin (called by DateArchivesMixin, ListingMixin,
+    #                  OptionalPagesMixin, PagesMixin) ------------------
+
+    @abstractmethod
+    def _get_global_context(self) -> dict[str, Any]:
+        """Return the global template context dict populated for the current build."""
+
+    @abstractmethod
+    def _get_search_url(self) -> str:
+        """Return the URL path for the configured search page."""
+
+    @abstractmethod
+    def _get_archive_url(self) -> str:
+        """Return the URL path for the configured archive page."""
+
+    @abstractmethod
+    def _get_tags_url(self) -> str:
+        """Return the URL path for the configured tags overview page."""
+
+    @abstractmethod
+    def _get_categories_url(self) -> str:
+        """Return the URL path for the configured categories overview page."""
+
+    @abstractmethod
+    def _get_stats_url(self) -> str:
+        """Return the URL path for the configured statistics page."""
+
+    @abstractmethod
+    def _get_calendar_url(self) -> str:
+        """Return the URL path for the configured calendar page."""
+
+    @abstractmethod
+    def _get_graph_url(self) -> str:
+        """Return the URL path for the configured graph page."""
+
+    # -- MinifyMixin (called by ListingMixin, OptionalPagesMixin,
+    #                 PagesMixin) ---------------------------------------
+
+    @abstractmethod
+    def _write_html(self, output_path: Path, html: str) -> None:
+        """Write *html* to *output_path*, minifying when configured."""
+
+    # -- PathsMixin (called by ListingMixin, PagesMixin) ---------------
+
+    @abstractmethod
+    def _get_pagination_url(self, base_url: str, page_num: int) -> str:
+        """Return the URL for *page_num* within *base_url*."""
+
+    @abstractmethod
+    def _build_pagination_page_urls(self, base_url: str, total_pages: int) -> list[str]:
+        """Return the full ordered list of page URLs for a paginated section."""
+
+    @abstractmethod
+    def _get_pagination_output_path(self, base_dir: Path, page_num: int) -> Path:
+        """Return the output file path for *page_num* inside *base_dir*."""
+
+    @abstractmethod
+    def _canonical_url_for_path(self, output_path: Path) -> str:
+        """Return the fully-qualified canonical URL for *output_path*."""
+
+    @staticmethod
+    @abstractmethod
+    def _pagination_prev_next(
+        page_num: int,
+        page_urls: list[str],
+    ) -> tuple[str | None, str | None]:
+        """Return ``(prev_url, next_url)`` for *page_num* in *page_urls*."""
+
+    # -- GroupingMixin (called by ListingMixin, OptionalPagesMixin) ----
+
+    @abstractmethod
+    def _group_posts_by_tag(
+        self, posts: list[Post]
+    ) -> dict[str, tuple[str, list[Post]]]:
+        """Return posts grouped by tag (case-insensitive)."""
+
+    @abstractmethod
+    def _group_posts_by_category(
+        self, posts: list[Post]
+    ) -> dict[str, tuple[str, list[Post]]]:
+        """Return posts grouped by category (case-insensitive)."""
+
+    @abstractmethod
+    def _calculate_cloud_font_sizes(
+        self,
+        data: list[dict[str, Any]],
+        min_size: float = 1.0,
+        max_size: float = 2.5,
+    ) -> None:
+        """Assign ``font_size`` to every item in a word-cloud data list."""
+
+    # -- ListingMixin (called by DateArchivesMixin — template method) --
+
+    @abstractmethod
+    def _generate_paginated_listing(
+        self,
+        post_list: list[Post],
+        base_url: str,
+        output_dir: Path,
+        posts_per_page: int,
+        context: dict[str, Any],
+        render_func: Callable[[list[Post], int, int], str],
+    ) -> None:
+        """Paginate *post_list* and write one HTML file per page."""
+
+
+### _base.py ends here

--- a/src/blogmore/generator/_context.py
+++ b/src/blogmore/generator/_context.py
@@ -9,6 +9,7 @@ from blogmore.clean_url import make_url_clean
 from blogmore.fontawesome import (
     FONTAWESOME_CDN_BRANDS_WOFF2_URL,
 )
+from blogmore.generator._base import GeneratorBase
 from blogmore.generator.constants import (
     ARCHIVE_CSS_FILENAME,
     CALENDAR_CSS_FILENAME,
@@ -27,24 +28,14 @@ from blogmore.generator.constants import (
 )
 from blogmore.generator.utils import minified_filename
 from blogmore.pagination_path import resolve_pagination_page_path
-from blogmore.site_config import SiteConfig
 
 
-class ContextMixin:
+class ContextMixin(GeneratorBase):
     """Mixin that builds template contexts and resolves configured page URLs.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `_fontawesome_css_url` (`str`)
-    - `_cache_bust_token` (`str`)
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
-
-    site_config: SiteConfig
-    _fontawesome_css_url: str
-    _cache_bust_token: str
 
     def _with_cache_bust(self, url: str) -> str:
         """Return a URL with a cache-busting query parameter appended.
@@ -191,8 +182,8 @@ class ContextMixin:
             "site_url": self.site_config.site_url,
             "tag_dir": TAG_DIR,
             "category_dir": CATEGORY_DIR,
-            "favicon_url": self._detect_favicon(),  # type: ignore[attr-defined]
-            "has_platform_icons": self._detect_generated_icons(),  # type: ignore[attr-defined]
+            "favicon_url": self._detect_favicon(),
+            "has_platform_icons": self._detect_generated_icons(),
             "blogmore_version": __version__,
             "with_search": self.site_config.with_search,
             "search_url": self._get_search_url(),

--- a/src/blogmore/generator/_date_archives.py
+++ b/src/blogmore/generator/_date_archives.py
@@ -6,27 +6,17 @@ import datetime as dt
 from collections import defaultdict
 from typing import Any
 
+from blogmore.generator._base import GeneratorBase
 from blogmore.parser import Page, Post
-from blogmore.renderer import TemplateRenderer
-from blogmore.site_config import SiteConfig
 
 
-class DateArchivesMixin:
+class DateArchivesMixin(GeneratorBase):
     """Mixin that generates year, month, and day archive pages with pagination.
 
     This mixin is intended to be composed into
     [`SiteGenerator`][blogmore.generator.site.SiteGenerator] via
-    [`ListingMixin`][blogmore.generator._listing.ListingMixin].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `renderer` ([`TemplateRenderer`][blogmore.renderer.TemplateRenderer])
-    - `POSTS_PER_PAGE_ARCHIVE` (`int`)
+    [`ListingMixin`][blogmore.generator._listing.ListingMixin].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    POSTS_PER_PAGE_ARCHIVE: int
 
     def _generate_date_archives(self, posts: list[Post], pages: list[Page]) -> None:
         """Generate date-based archive pages (year, month, day) with pagination.
@@ -50,7 +40,7 @@ class DateArchivesMixin:
                 posts_by_month[(year, month)].append(post)
                 posts_by_day[(year, month, day)].append(post)
 
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
 
         # Generate year archives with pagination
@@ -76,7 +66,7 @@ class DateArchivesMixin:
                     **_ctx,
                 )
 
-            self._generate_paginated_listing(  # type: ignore[attr-defined]
+            self._generate_paginated_listing(
                 year_posts,
                 base_url=base_path,
                 output_dir=year_dir,
@@ -109,7 +99,7 @@ class DateArchivesMixin:
                     **_ctx,
                 )
 
-            self._generate_paginated_listing(  # type: ignore[attr-defined]
+            self._generate_paginated_listing(
                 month_posts,
                 base_url=base_path,
                 output_dir=month_dir,
@@ -144,7 +134,7 @@ class DateArchivesMixin:
                     **_ctx,
                 )
 
-            self._generate_paginated_listing(  # type: ignore[attr-defined]
+            self._generate_paginated_listing(
                 day_posts,
                 base_url=base_path,
                 output_dir=day_dir,

--- a/src/blogmore/generator/_grouping.py
+++ b/src/blogmore/generator/_grouping.py
@@ -3,15 +3,16 @@
 from collections.abc import Callable
 from typing import Any
 
+from blogmore.generator._base import GeneratorBase
 from blogmore.parser import Post
 
 
-class GroupingMixin:
+class GroupingMixin(GeneratorBase):
     """Mixin that groups posts by tag or category and calculates word-cloud sizes.
 
     This mixin is intended to be composed into
     [`SiteGenerator`][blogmore.generator.site.SiteGenerator] alongside the
-    other mixin classes.  It has no instance-variable dependencies of its own.
+    other mixin classes.
     """
 
     def _group_posts_by_attribute(

--- a/src/blogmore/generator/_listing.py
+++ b/src/blogmore/generator/_listing.py
@@ -10,29 +10,14 @@ from blogmore.generator._date_archives import DateArchivesMixin
 from blogmore.generator.constants import CATEGORY_DIR, TAG_DIR
 from blogmore.generator.utils import paginate_posts
 from blogmore.parser import Page, Post, post_sort_key, sanitize_for_url
-from blogmore.renderer import TemplateRenderer
-from blogmore.site_config import SiteConfig
 
 
 class ListingMixin(DateArchivesMixin):
     """Mixin that generates paginated listing pages for archives, tags, and categories.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `renderer` ([`TemplateRenderer`][blogmore.renderer.TemplateRenderer])
-    - `POSTS_PER_PAGE_TAG` (`int`)
-    - `POSTS_PER_PAGE_CATEGORY` (`int`)
-    - `POSTS_PER_PAGE_ARCHIVE` (`int`)
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    POSTS_PER_PAGE_TAG: int
-    POSTS_PER_PAGE_CATEGORY: int
-    POSTS_PER_PAGE_ARCHIVE: int
 
     def _generate_paginated_listing(
         self,
@@ -66,17 +51,17 @@ class ListingMixin(DateArchivesMixin):
         """
         paginated_posts = paginate_posts(post_list, posts_per_page)
         total_pages = len(paginated_posts)
-        page_urls = self._build_pagination_page_urls(base_url, total_pages)  # type: ignore[attr-defined]
+        page_urls = self._build_pagination_page_urls(base_url, total_pages)
 
         for page_num, page_posts in enumerate(paginated_posts, start=1):
-            output_path = self._get_pagination_output_path(output_dir, page_num)  # type: ignore[attr-defined]
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
-            prev_url, next_url = self._pagination_prev_next(page_num, page_urls)  # type: ignore[attr-defined]
+            output_path = self._get_pagination_output_path(output_dir, page_num)
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
+            prev_url, next_url = self._pagination_prev_next(page_num, page_urls)
             context["prev_page_url"] = prev_url
             context["next_page_url"] = next_url
             context["pagination_page_urls"] = page_urls
             html = render_func(page_posts, page_num, total_pages)
-            self._write_html(output_path, html)  # type: ignore[attr-defined]
+            self._write_html(output_path, html)
 
     def _generate_tag_pages(self, posts: list[Post], pages: list[Page]) -> None:
         """Generate pages for each tag with pagination.
@@ -87,7 +72,7 @@ class ListingMixin(DateArchivesMixin):
         """
         # Group posts by tag (case-insensitive)
         # Key is lowercase tag, value is (display_name, posts)
-        posts_by_tag = self._group_posts_by_tag(posts)  # type: ignore[attr-defined]
+        posts_by_tag = self._group_posts_by_tag(posts)
 
         # Create tag directory
         tag_dir = self.site_config.output_dir / TAG_DIR
@@ -105,7 +90,7 @@ class ListingMixin(DateArchivesMixin):
             # Each tag's pages live inside tag/{safe_tag}/ directory.
             tag_base_dir = tag_dir / safe_tag
 
-            context = self._get_global_context()  # type: ignore[attr-defined]
+            context = self._get_global_context()
             context["pages"] = pages
 
             # Default parameter values bind the current loop variables at
@@ -145,7 +130,7 @@ class ListingMixin(DateArchivesMixin):
             pages: All static pages, for sidebar navigation.
         """
         # Group posts by tag to get counts
-        posts_by_tag = self._group_posts_by_tag(posts)  # type: ignore[attr-defined]
+        posts_by_tag = self._group_posts_by_tag(posts)
 
         if not posts_by_tag:
             # No tags, skip generation
@@ -165,16 +150,16 @@ class ListingMixin(DateArchivesMixin):
         # Sort alphabetically by display name
         tag_data.sort(key=lambda x: x["display_name"].lower())
 
-        self._calculate_cloud_font_sizes(tag_data)  # type: ignore[attr-defined]
+        self._calculate_cloud_font_sizes(tag_data)
 
         # Render the tags page
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.tags_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        tags_url = self._get_tags_url()  # type: ignore[attr-defined]
+        tags_url = self._get_tags_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{tags_url}"
@@ -182,11 +167,11 @@ class ListingMixin(DateArchivesMixin):
                 else tags_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
 
         html = self.renderer.render_tags_page(tag_data, **context)
 
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_categories_page(self, posts: list[Post], pages: list[Page]) -> None:
         """Generate the categories overview page with word cloud.
@@ -196,7 +181,7 @@ class ListingMixin(DateArchivesMixin):
             pages: All static pages, for sidebar navigation.
         """
         # Group posts by category to get counts
-        posts_by_category = self._group_posts_by_category(posts)  # type: ignore[attr-defined]
+        posts_by_category = self._group_posts_by_category(posts)
 
         if not posts_by_category:
             # No categories, skip generation
@@ -219,16 +204,16 @@ class ListingMixin(DateArchivesMixin):
         # Sort alphabetically by display name
         category_data.sort(key=lambda x: x["display_name"].lower())
 
-        self._calculate_cloud_font_sizes(category_data)  # type: ignore[attr-defined]
+        self._calculate_cloud_font_sizes(category_data)
 
         # Render the categories page
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.categories_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        categories_url = self._get_categories_url()  # type: ignore[attr-defined]
+        categories_url = self._get_categories_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{categories_url}"
@@ -236,11 +221,11 @@ class ListingMixin(DateArchivesMixin):
                 else categories_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
 
         html = self.renderer.render_categories_page(category_data, **context)
 
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_category_pages(self, posts: list[Post], pages: list[Page]) -> None:
         """Generate pages for each category with pagination.
@@ -251,7 +236,7 @@ class ListingMixin(DateArchivesMixin):
         """
         # Group posts by category (case-insensitive)
         # Key is lowercase category, value is (display_name, posts)
-        posts_by_category = self._group_posts_by_category(posts)  # type: ignore[attr-defined]
+        posts_by_category = self._group_posts_by_category(posts)
 
         # Create category directory
         category_dir = self.site_config.output_dir / CATEGORY_DIR
@@ -272,7 +257,7 @@ class ListingMixin(DateArchivesMixin):
             # Each category's pages live inside category/{safe_category}/ directory.
             category_base_dir = category_dir / safe_category
 
-            context = self._get_global_context()  # type: ignore[attr-defined]
+            context = self._get_global_context()
             context["pages"] = pages
 
             def _render_category(

--- a/src/blogmore/generator/_minify.py
+++ b/src/blogmore/generator/_minify.py
@@ -10,26 +10,22 @@ import rcssmin  # type: ignore[import-untyped]
 import rjsmin  # type: ignore[import-untyped]
 
 from blogmore.code_styles import build_code_css
+from blogmore.generator._base import GeneratorBase
 from blogmore.generator.constants import (
     _PAGE_SPECIFIC_CSS,
     CODE_CSS_FILENAME,
     CSS_FILENAME,
 )
 from blogmore.generator.utils import minified_filename
-from blogmore.site_config import SiteConfig
 
 
-class MinifyMixin:
+class MinifyMixin(GeneratorBase):
     """Mixin that writes HTML pages and minifies CSS/JS assets.
 
     This mixin is intended to be composed into
     [`SiteGenerator`][blogmore.generator.site.SiteGenerator] (via
-    [`AssetsMixin`][blogmore.generator._assets.AssetsMixin]).  It expects
-    the host class to provide a ``site_config`` attribute of type
-    [`SiteConfig`][blogmore.site_config.SiteConfig].
+    [`AssetsMixin`][blogmore.generator._assets.AssetsMixin]).
     """
-
-    site_config: SiteConfig
 
     def _write_html(self, output_path: Path, html: str) -> None:
         """Write an HTML string to a file, minifying it when configured to do so.

--- a/src/blogmore/generator/_optional_pages.py
+++ b/src/blogmore/generator/_optional_pages.py
@@ -8,32 +8,22 @@ from blogmore.backlinks import Backlink
 from blogmore.calendar import CalendarYear, build_calendar
 from blogmore.clean_url import make_url_clean
 from blogmore.feeds import BlogFeedGenerator
+from blogmore.generator._base import GeneratorBase
 from blogmore.generator.constants import CATEGORY_DIR, TAG_DIR
 from blogmore.graph import GraphData, build_graph_data
 from blogmore.parser import Page, Post, post_sort_key
-from blogmore.renderer import TemplateRenderer
 from blogmore.search import write_search_index
-from blogmore.site_config import SiteConfig
 from blogmore.sitemap import write_sitemap
 from blogmore.stats import BlogStats, compute_blog_stats
 
 
-class OptionalPagesMixin:
+class OptionalPagesMixin(GeneratorBase):
     """Mixin that generates optional-feature pages (feeds, search, stats, calendar, graph).
 
     This mixin is intended to be composed into
     [`SiteGenerator`][blogmore.generator.site.SiteGenerator] via
-    [`PagesMixin`][blogmore.generator._pages.PagesMixin].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `renderer` ([`TemplateRenderer`][blogmore.renderer.TemplateRenderer])
-    - `_extras_html_paths` (`frozenset[str]`)
+    [`PagesMixin`][blogmore.generator._pages.PagesMixin].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    _extras_html_paths: frozenset[str]
 
     def _generate_feeds(self, posts: list[Post]) -> None:
         """Generate RSS and Atom feeds.
@@ -52,7 +42,7 @@ class OptionalPagesMixin:
         feed_gen.generate_index_feeds(posts)
 
         # Generate category feeds
-        posts_by_category = self._group_posts_by_category(posts)  # type: ignore[attr-defined]
+        posts_by_category = self._group_posts_by_category(posts)
         # Sort posts by date for each category
         for _category_lower, (
             _category_display,
@@ -76,13 +66,13 @@ class OptionalPagesMixin:
         Args:
             pages: List of static pages (for the sidebar navigation).
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.search_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        search_url = self._get_search_url()  # type: ignore[attr-defined]
+        search_url = self._get_search_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{search_url}"
@@ -90,9 +80,9 @@ class OptionalPagesMixin:
                 else search_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         html = self.renderer.render_search_page(**context)
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_stats_page(
         self,
@@ -109,13 +99,13 @@ class OptionalPagesMixin:
                 [`Backlink`][blogmore.backlinks.Backlink] objects.  When provided,
                 the statistics page includes a "Top Internal Links" section.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.stats_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        stats_url = self._get_stats_url()  # type: ignore[attr-defined]
+        stats_url = self._get_stats_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{stats_url}"
@@ -123,12 +113,12 @@ class OptionalPagesMixin:
                 else stats_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         blog_stats: BlogStats = compute_blog_stats(
             posts, self.site_config.site_url, backlink_map
         )
         html = self.renderer.render_stats_page(stats=blog_stats, **context)
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_calendar_page(self, posts: list[Post], pages: list[Page]) -> None:
         """Generate the calendar view page.
@@ -137,13 +127,13 @@ class OptionalPagesMixin:
             posts: All published posts; used to populate the calendar grid.
             pages: List of static pages (for the sidebar navigation).
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.calendar_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        calendar_url = self._get_calendar_url()  # type: ignore[attr-defined]
+        calendar_url = self._get_calendar_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{calendar_url}"
@@ -151,7 +141,7 @@ class OptionalPagesMixin:
                 else calendar_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         # Determine page1_suffix for archive URL construction.  When
         # clean_urls is enabled, strip any index filename (e.g. "index.html")
         # so that calendar links to year/month/day archives end with a
@@ -165,7 +155,7 @@ class OptionalPagesMixin:
         html = self.renderer.render_calendar_page(
             calendar_years=calendar_years, **context
         )
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_graph_page(self, posts: list[Post], pages: list[Page]) -> None:
         """Generate the post-relationship graph page.
@@ -174,13 +164,13 @@ class OptionalPagesMixin:
             posts: All published posts; used to build graph nodes and edges.
             pages: List of static pages (for the sidebar navigation).
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.graph_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        graph_url = self._get_graph_url()  # type: ignore[attr-defined]
+        graph_url = self._get_graph_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{graph_url}"
@@ -188,7 +178,7 @@ class OptionalPagesMixin:
                 else graph_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         graph_data: GraphData = build_graph_data(
             posts,
             tag_dir=TAG_DIR,
@@ -198,7 +188,7 @@ class OptionalPagesMixin:
         html = self.renderer.render_graph_page(
             graph_data_json=graph_data.to_json(), **context
         )
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _remove_stale_search_files(self) -> None:
         """Remove search-related files left over from a previous build.

--- a/src/blogmore/generator/_pages.py
+++ b/src/blogmore/generator/_pages.py
@@ -9,27 +9,14 @@ from blogmore.clean_url import make_url_clean
 from blogmore.comment_invite import build_mailto_url, get_invite_email_for_post
 from blogmore.generator._optional_pages import OptionalPagesMixin
 from blogmore.parser import CUSTOM_404_HTML, Page, Post
-from blogmore.renderer import TemplateRenderer
-from blogmore.site_config import SiteConfig
 
 
 class PagesMixin(OptionalPagesMixin):
     """Mixin that generates each type of HTML page written to the output directory.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `renderer` ([`TemplateRenderer`][blogmore.renderer.TemplateRenderer])
-    - `POSTS_PER_PAGE_INDEX` (`int`)
-    - `_extras_html_paths` (`frozenset[str]`)
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    POSTS_PER_PAGE_INDEX: int
-    _extras_html_paths: frozenset[str]
 
     def _generate_post_page(
         self,
@@ -51,7 +38,7 @@ class PagesMixin(OptionalPagesMixin):
                 ``None`` or when the post URL has no entry, an empty list is
                 used so the template always receives a ``backlinks`` variable.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["all_posts"] = all_posts
         context["pages"] = pages
 
@@ -97,9 +84,9 @@ class PagesMixin(OptionalPagesMixin):
                 else post.url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         html = self.renderer.render_post(post, **context)
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_page(self, page: Page, pages: list[Page], output_path: Path) -> None:
         """Generate a single static page.
@@ -109,16 +96,16 @@ class PagesMixin(OptionalPagesMixin):
             pages: All static pages, passed to the template context.
             output_path: The pre-resolved absolute output file path for this page.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+        context["canonical_url"] = self._canonical_url_for_path(output_path)
 
         html = self.renderer.render_page(page, **context)
 
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_404_page(self, page: Page, pages: list[Page]) -> None:
         """Generate the custom 404 page in the root of the output directory.
@@ -127,14 +114,14 @@ class PagesMixin(OptionalPagesMixin):
             page: The 404 page content to render.
             pages: All static pages, passed to the template context.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = self.site_config.output_dir / CUSTOM_404_HTML
-        context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+        context["canonical_url"] = self._canonical_url_for_path(output_path)
 
         html = self.renderer.render_page(page, **context)
 
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_index_page(self, posts: list[Post], pages: list[Page]) -> None:
         """Generate the main index page with pagination.
@@ -152,7 +139,7 @@ class PagesMixin(OptionalPagesMixin):
         """
         from blogmore.generator.utils import paginate_posts
 
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
 
         # Paginate posts
@@ -168,7 +155,7 @@ class PagesMixin(OptionalPagesMixin):
         if self.site_config.clean_urls:
             page1_url = make_url_clean(page1_url)
         page_urls = [page1_url] + [
-            self._get_pagination_url("", page_num)  # type: ignore[attr-defined]
+            self._get_pagination_url("", page_num)
             for page_num in range(2, total_pages + 1)
         ]
 
@@ -178,11 +165,11 @@ class PagesMixin(OptionalPagesMixin):
                 output_path = self.site_config.output_dir / "index.html"
                 output_path.parent.mkdir(parents=True, exist_ok=True)
             else:
-                output_path = self._get_pagination_output_path(  # type: ignore[attr-defined]
+                output_path = self._get_pagination_output_path(
                     self.site_config.output_dir, page_num
                 )
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
-            prev_url, next_url = self._pagination_prev_next(page_num, page_urls)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
+            prev_url, next_url = self._pagination_prev_next(page_num, page_urls)
             context["prev_page_url"] = prev_url
             context["next_page_url"] = next_url
             context["pagination_page_urls"] = page_urls
@@ -190,7 +177,7 @@ class PagesMixin(OptionalPagesMixin):
                 page_posts, page=page_num, total_pages=total_pages, **context
             )
 
-            self._write_html(output_path, html)  # type: ignore[attr-defined]
+            self._write_html(output_path, html)
 
     def _generate_archive_page(self, posts: list[Post], pages: list[Page]) -> None:
         """Generate the archive page.
@@ -199,13 +186,13 @@ class PagesMixin(OptionalPagesMixin):
             posts: All published posts.
             pages: All static pages, for sidebar navigation.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.archive_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        archive_url = self._get_archive_url()  # type: ignore[attr-defined]
+        archive_url = self._get_archive_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{archive_url}"
@@ -213,10 +200,10 @@ class PagesMixin(OptionalPagesMixin):
                 else archive_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         html = self.renderer.render_archive(
             posts, page=1, total_pages=1, base_path="/archive", **context
         )
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     ### _pages.py ends here

--- a/src/blogmore/generator/_paths.py
+++ b/src/blogmore/generator/_paths.py
@@ -6,23 +6,19 @@ from collections import defaultdict
 from pathlib import Path
 
 from blogmore.clean_url import make_url_clean
+from blogmore.generator._base import GeneratorBase
 from blogmore.page_path import compute_page_output_path
 from blogmore.pagination_path import resolve_pagination_page_path
 from blogmore.parser import Page, Post
 from blogmore.post_path import compute_output_path
-from blogmore.site_config import SiteConfig
 
 
-class PathsMixin:
+class PathsMixin(GeneratorBase):
     """Mixin that resolves pagination paths, canonical URLs, and output paths.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide a ``site_config`` attribute of type
-    [`SiteConfig`][blogmore.site_config.SiteConfig].
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
-
-    site_config: SiteConfig
 
     def _get_pagination_url(self, base_url: str, page_num: int) -> str:
         """Compute the URL for a given pagination page.


### PR DESCRIPTION
Prompt was:

> Within @src/blogmore/generator/ there is a lot of `type: ignore[attr-defined]`. This seems to be down to the current mixin implementation. I'm happy with the use of mixins, but I'd like for this to be done in a way where we don't have to use pragmas that ignore type checking. Propose a way that this can be cleaned up.
>
> Be sure to take the contents of @AGENTS.md into account, so that you fully undersatnd the project's standards and current layout.

In respect to #447.

https://blog.davep.org/2026/05/04/i-wouldnt-start-from-here.html