### PR TITLE
Clean up the type checking of the generator (Gemini edition)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,11 +95,13 @@ appropriately-named module rather than growing an existing large file.
 ## Code style
 
 - Always write full type hints that pass `mypy` in strict mode.
-- When a mixin method in `src/blogmore/generator/` needs to call a method
-  defined in another mixin, use [`GeneratorProtocol`][blogmore.generator._protocol.GeneratorProtocol]
-  as the type for `self` to ensure type safety while avoiding circular imports.
-  Always use `from __future__ import annotations` and the `if TYPE_CHECKING:`
-  idiom for this.
+- When writing methods in `src/blogmore/generator/` mixins, always type `self`
+  as [`GeneratorProtocol`][blogmore.generator._protocol.GeneratorProtocol].
+  This provides type-safe access to shared attributes (`site_config`,
+  `renderer`) and methods defined in other mixins without requiring circular
+  imports or redundant class-level declarations. Always use
+  `from __future__ import annotations` and the `if TYPE_CHECKING:` idiom for
+  this.
 - If a third-party library lacks type hints, search for a companion type-stub
   package (e.g. `types-*`) before adding `# type: ignore` comments.
 - Always generate full Google-style docstrings for every module, class,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ All source lives in `src/blogmore/`. Key modules and their responsibilities:
 | `content_path.py` | Shared path-resolution utilities for content output paths (used by page_path and post_path) |
 | `clean_url.py` | Clean URL transformation utilities (removes index.html from URLs when enabled) |
 | `page_path.py` | Page path resolution for configurable output file paths |
+| `backlinks.py` | Internal link analysis and backlink map generation |
+| `calendar.py` | Calendar grid calculation and data structures |
+| `graph.py` | Post relationship graph data generation (JSON) |
+| `stats.py` | Blog statistics computation (word counts, top tags, etc.) |
+| `comment_invite.py` | mailto: URL generation for "Invite comments" links |
+| `code_styles.py` | Pygments-based CSS generation for code blocks |
 | `utils.py` | Shared utility helpers |
 
 The `generator/` sub-package (`src/blogmore/generator/`) breaks the site
@@ -33,6 +39,7 @@ generator into focused modules and mixin classes:
 |---|---|
 | `generator/constants.py` | Filename constants, `TAG_DIR`, `CATEGORY_DIR`, `_PAGE_SPECIFIC_CSS` |
 | `generator/utils.py` | `minified_filename`, `paginate_posts` |
+| `generator/_protocol.py` | `GeneratorProtocol` — defines the combined interface of all mixins for type safety |
 | `generator/_grouping.py` | `GroupingMixin` — post grouping by tag/category; word-cloud font-size interpolation |
 | `generator/_context.py` | `ContextMixin` — global template context, asset URL helpers, cache-busting |
 | `generator/_paths.py` | `PathsMixin` — pagination paths, canonical URLs, output path resolution, sidebar filtering |
@@ -64,7 +71,7 @@ SiteGenerator(
 ```
 
 The `markdown/` sub-package (`src/blogmore/markdown/`) groups all custom
-Markdown extensions:
+Markdown extensions and utility modules:
 
 | Module | Responsibility |
 |---|---|
@@ -72,9 +79,12 @@ Markdown extensions:
 | `markdown/external_links.py` | Markdown extension: opens external links in a new tab |
 | `markdown/heading_anchors.py` | Markdown extension: hover anchor links on headings |
 | `markdown/strikethrough.py` | Markdown extension: `~~strikethrough~~` syntax |
+| `markdown/plain_text.py` | Markdown-to-plain-text conversion; **single source of truth for the custom extension set** |
+| `markdown/first_paragraph.py` | Logic for extracting the first meaningful paragraph as plain text |
 
 Any new Markdown extensions must be added as a new module inside
-`src/blogmore/markdown/` and registered in `parser.py`.
+`src/blogmore/markdown/`, registered in `create_custom_extensions` in
+`markdown/plain_text.py`, and imported in `parser.py`.
 
 Templates live in `src/blogmore/templates/`; the stylesheet is
 `src/blogmore/templates/static/style.css`.
@@ -85,6 +95,11 @@ appropriately-named module rather than growing an existing large file.
 ## Code style
 
 - Always write full type hints that pass `mypy` in strict mode.
+- When a mixin method in `src/blogmore/generator/` needs to call a method
+  defined in another mixin, use [`GeneratorProtocol`][blogmore.generator._protocol.GeneratorProtocol]
+  as the type for `self` to ensure type safety while avoiding circular imports.
+  Always use `from __future__ import annotations` and the `if TYPE_CHECKING:`
+  idiom for this.
 - If a third-party library lacks type hints, search for a companion type-stub
   package (e.g. `types-*`) before adding `# type: ignore` comments.
 - Always generate full Google-style docstrings for every module, class,

--- a/src/blogmore/generator/_assets.py
+++ b/src/blogmore/generator/_assets.py
@@ -2,11 +2,13 @@
 [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
 """
 
+from __future__ import annotations
+
 import shutil
 import urllib.error
 from importlib.resources import files
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from blogmore.fontawesome import (
     FONTAWESOME_CDN_CSS_URL,
@@ -24,29 +26,20 @@ from blogmore.generator.constants import (
     THEME_JS_FILENAME,
 )
 from blogmore.icons import IconGenerator, detect_source_icon
-from blogmore.renderer import TemplateRenderer
-from blogmore.site_config import SiteConfig
+
+if TYPE_CHECKING:
+    from blogmore.generator._protocol import GeneratorProtocol
 
 
 class AssetsMixin(MinifyMixin):
     """Mixin that manages icon generation and static file copying.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `_fontawesome_css_url` (`str`)
-    - `_extras_html_paths` (`frozenset[str]`)
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
 
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    _fontawesome_css_url: str
-    _extras_html_paths: frozenset[str]
-
     @property
-    def _content_dir(self) -> Path:
+    def _content_dir(self: GeneratorProtocol) -> Path:
         """Return the content directory as a ``Path``, guaranteed non-``None``.
 
         Returns:
@@ -55,7 +48,7 @@ class AssetsMixin(MinifyMixin):
         assert self.site_config.content_dir is not None
         return self.site_config.content_dir
 
-    def _detect_favicon(self) -> str | None:
+    def _detect_favicon(self: GeneratorProtocol) -> str | None:
         """Detect if a favicon file exists in the icons or extras directory.
 
         Checks for favicon files with common extensions in priority order.
@@ -88,7 +81,7 @@ class AssetsMixin(MinifyMixin):
 
         return None
 
-    def _detect_generated_icons(self) -> bool:
+    def _detect_generated_icons(self: GeneratorProtocol) -> bool:
         """Detect if generated platform icons exist in the icons directory.
 
         Returns:
@@ -102,7 +95,7 @@ class AssetsMixin(MinifyMixin):
         apple_icon_path = icons_dir / "apple-touch-icon.png"
         return apple_icon_path.is_file()
 
-    def _generate_icons(self) -> None:
+    def _generate_icons(self: GeneratorProtocol) -> None:
         """Generate icons from a source image if present."""
         extras_dir = self._content_dir / "extras"
 
@@ -132,7 +125,7 @@ class AssetsMixin(MinifyMixin):
             else:
                 print("Warning: No icons were generated")
 
-    def _prepare_fontawesome_css(self) -> str | None:
+    def _prepare_fontawesome_css(self: GeneratorProtocol) -> str | None:
         """Determine the FontAwesome CSS URL and optionally build optimised CSS.
 
         Extracts the social icon names from the sidebar configuration and
@@ -174,7 +167,7 @@ class AssetsMixin(MinifyMixin):
         )
         return optimizer.build_css(metadata)
 
-    def _copy_static_assets(self) -> None:
+    def _copy_static_assets(self: GeneratorProtocol) -> None:
         """Copy static assets (CSS, JS, images) to output directory.
 
         When ``minify_css`` is enabled, ``style.css`` and all page-specific
@@ -304,7 +297,7 @@ class AssetsMixin(MinifyMixin):
             if self.site_config.with_graph:
                 self._write_minified_js(output_static, GRAPH_JS_FILENAME)
 
-    def _copy_extras(self) -> None:
+    def _copy_extras(self: GeneratorProtocol) -> None:
         """Copy extra files from the extras directory to the output directory.
 
         Files in the extras directory are copied to the output root, preserving

--- a/src/blogmore/generator/_context.py
+++ b/src/blogmore/generator/_context.py
@@ -29,7 +29,6 @@ from blogmore.generator.constants import (
 )
 from blogmore.generator.utils import minified_filename
 from blogmore.pagination_path import resolve_pagination_page_path
-from blogmore.site_config import SiteConfig
 
 if TYPE_CHECKING:
     from blogmore.generator._protocol import GeneratorProtocol
@@ -39,19 +38,10 @@ class ContextMixin:
     """Mixin that builds template contexts and resolves configured page URLs.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `_fontawesome_css_url` (`str`)
-    - `_cache_bust_token` (`str`)
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
 
-    site_config: SiteConfig
-    _fontawesome_css_url: str
-    _cache_bust_token: str
-
-    def _with_cache_bust(self, url: str) -> str:
+    def _with_cache_bust(self: GeneratorProtocol, url: str) -> str:
         """Return a URL with a cache-busting query parameter appended.
 
         External URLs (i.e. those that start with ``http://`` or ``https://``)
@@ -76,7 +66,7 @@ class ContextMixin:
             return url
         return f"{url}?v={self._cache_bust_token}"
 
-    def _get_configured_url(self, path_field_name: str) -> str:
+    def _get_configured_url(self: GeneratorProtocol, path_field_name: str) -> str:
         """Return the URL path for a configured page, derived from a config field.
 
         Strips any leading slash from the config value, prepends a fresh
@@ -96,7 +86,7 @@ class ContextMixin:
             url = make_url_clean(url)
         return url
 
-    def _get_search_url(self) -> str:
+    def _get_search_url(self: GeneratorProtocol) -> str:
         """Return the URL path for the configured search page.
 
         Returns:
@@ -104,7 +94,7 @@ class ContextMixin:
         """
         return self._get_configured_url("search_path")
 
-    def _get_archive_url(self) -> str:
+    def _get_archive_url(self: GeneratorProtocol) -> str:
         """Return the URL path for the configured archive page.
 
         Returns:
@@ -112,7 +102,7 @@ class ContextMixin:
         """
         return self._get_configured_url("archive_path")
 
-    def _get_tags_url(self) -> str:
+    def _get_tags_url(self: GeneratorProtocol) -> str:
         """Return the URL path for the configured tags overview page.
 
         Returns:
@@ -120,7 +110,7 @@ class ContextMixin:
         """
         return self._get_configured_url("tags_path")
 
-    def _get_categories_url(self) -> str:
+    def _get_categories_url(self: GeneratorProtocol) -> str:
         """Return the URL path for the configured categories overview page.
 
         Returns:
@@ -128,7 +118,7 @@ class ContextMixin:
         """
         return self._get_configured_url("categories_path")
 
-    def _get_stats_url(self) -> str:
+    def _get_stats_url(self: GeneratorProtocol) -> str:
         """Return the URL path for the configured statistics page.
 
         Returns:
@@ -136,7 +126,7 @@ class ContextMixin:
         """
         return self._get_configured_url("stats_path")
 
-    def _get_calendar_url(self) -> str:
+    def _get_calendar_url(self: GeneratorProtocol) -> str:
         """Return the URL path for the configured calendar page.
 
         Returns:
@@ -144,7 +134,7 @@ class ContextMixin:
         """
         return self._get_configured_url("calendar_path")
 
-    def _get_graph_url(self) -> str:
+    def _get_graph_url(self: GeneratorProtocol) -> str:
         """Return the URL path for the configured graph page.
 
         Returns:
@@ -153,7 +143,7 @@ class ContextMixin:
         return self._get_configured_url("graph_path")
 
     def _get_asset_url(
-        self,
+        self: GeneratorProtocol,
         regular: str,
         minify: bool,
         *,

--- a/src/blogmore/generator/_context.py
+++ b/src/blogmore/generator/_context.py
@@ -2,7 +2,9 @@
 [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
 """
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from blogmore import __version__
 from blogmore.clean_url import make_url_clean
@@ -28,6 +30,9 @@ from blogmore.generator.constants import (
 from blogmore.generator.utils import minified_filename
 from blogmore.pagination_path import resolve_pagination_page_path
 from blogmore.site_config import SiteConfig
+
+if TYPE_CHECKING:
+    from blogmore.generator._protocol import GeneratorProtocol
 
 
 class ContextMixin:
@@ -174,7 +179,7 @@ class ContextMixin:
         url = f"/static/{name}"
         return self._with_cache_bust(url) if cache_bust else url
 
-    def _get_global_context(self) -> dict[str, Any]:
+    def _get_global_context(self: GeneratorProtocol) -> dict[str, Any]:
         """Get the global context available to all templates.
 
         Returns:
@@ -191,8 +196,8 @@ class ContextMixin:
             "site_url": self.site_config.site_url,
             "tag_dir": TAG_DIR,
             "category_dir": CATEGORY_DIR,
-            "favicon_url": self._detect_favicon(),  # type: ignore[attr-defined]
-            "has_platform_icons": self._detect_generated_icons(),  # type: ignore[attr-defined]
+            "favicon_url": self._detect_favicon(),
+            "has_platform_icons": self._detect_generated_icons(),
             "blogmore_version": __version__,
             "with_search": self.site_config.with_search,
             "search_url": self._get_search_url(),

--- a/src/blogmore/generator/_date_archives.py
+++ b/src/blogmore/generator/_date_archives.py
@@ -2,13 +2,18 @@
 [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
 """
 
+from __future__ import annotations
+
 import datetime as dt
 from collections import defaultdict
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from blogmore.parser import Page, Post
 from blogmore.renderer import TemplateRenderer
 from blogmore.site_config import SiteConfig
+
+if TYPE_CHECKING:
+    from blogmore.generator._protocol import GeneratorProtocol
 
 
 class DateArchivesMixin:
@@ -28,7 +33,9 @@ class DateArchivesMixin:
     renderer: TemplateRenderer
     POSTS_PER_PAGE_ARCHIVE: int
 
-    def _generate_date_archives(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_date_archives(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate date-based archive pages (year, month, day) with pagination.
 
         Args:
@@ -50,7 +57,7 @@ class DateArchivesMixin:
                 posts_by_month[(year, month)].append(post)
                 posts_by_day[(year, month, day)].append(post)
 
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
 
         # Generate year archives with pagination
@@ -76,7 +83,7 @@ class DateArchivesMixin:
                     **_ctx,
                 )
 
-            self._generate_paginated_listing(  # type: ignore[attr-defined]
+            self._generate_paginated_listing(
                 year_posts,
                 base_url=base_path,
                 output_dir=year_dir,
@@ -109,7 +116,7 @@ class DateArchivesMixin:
                     **_ctx,
                 )
 
-            self._generate_paginated_listing(  # type: ignore[attr-defined]
+            self._generate_paginated_listing(
                 month_posts,
                 base_url=base_path,
                 output_dir=month_dir,
@@ -144,7 +151,7 @@ class DateArchivesMixin:
                     **_ctx,
                 )
 
-            self._generate_paginated_listing(  # type: ignore[attr-defined]
+            self._generate_paginated_listing(
                 day_posts,
                 base_url=base_path,
                 output_dir=day_dir,

--- a/src/blogmore/generator/_date_archives.py
+++ b/src/blogmore/generator/_date_archives.py
@@ -9,8 +9,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from blogmore.parser import Page, Post
-from blogmore.renderer import TemplateRenderer
-from blogmore.site_config import SiteConfig
 
 if TYPE_CHECKING:
     from blogmore.generator._protocol import GeneratorProtocol
@@ -21,17 +19,8 @@ class DateArchivesMixin:
 
     This mixin is intended to be composed into
     [`SiteGenerator`][blogmore.generator.site.SiteGenerator] via
-    [`ListingMixin`][blogmore.generator._listing.ListingMixin].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `renderer` ([`TemplateRenderer`][blogmore.renderer.TemplateRenderer])
-    - `POSTS_PER_PAGE_ARCHIVE` (`int`)
+    [`ListingMixin`][blogmore.generator._listing.ListingMixin].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    POSTS_PER_PAGE_ARCHIVE: int
 
     def _generate_date_archives(
         self: GeneratorProtocol, posts: list[Post], pages: list[Page]

--- a/src/blogmore/generator/_listing.py
+++ b/src/blogmore/generator/_listing.py
@@ -2,9 +2,11 @@
 [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
 """
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from blogmore.generator._date_archives import DateArchivesMixin
 from blogmore.generator.constants import CATEGORY_DIR, TAG_DIR
@@ -12,6 +14,9 @@ from blogmore.generator.utils import paginate_posts
 from blogmore.parser import Page, Post, post_sort_key, sanitize_for_url
 from blogmore.renderer import TemplateRenderer
 from blogmore.site_config import SiteConfig
+
+if TYPE_CHECKING:
+    from blogmore.generator._protocol import GeneratorProtocol
 
 
 class ListingMixin(DateArchivesMixin):
@@ -35,7 +40,7 @@ class ListingMixin(DateArchivesMixin):
     POSTS_PER_PAGE_ARCHIVE: int
 
     def _generate_paginated_listing(
-        self,
+        self: GeneratorProtocol,
         post_list: list[Post],
         base_url: str,
         output_dir: Path,
@@ -66,19 +71,21 @@ class ListingMixin(DateArchivesMixin):
         """
         paginated_posts = paginate_posts(post_list, posts_per_page)
         total_pages = len(paginated_posts)
-        page_urls = self._build_pagination_page_urls(base_url, total_pages)  # type: ignore[attr-defined]
+        page_urls = self._build_pagination_page_urls(base_url, total_pages)
 
         for page_num, page_posts in enumerate(paginated_posts, start=1):
-            output_path = self._get_pagination_output_path(output_dir, page_num)  # type: ignore[attr-defined]
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
-            prev_url, next_url = self._pagination_prev_next(page_num, page_urls)  # type: ignore[attr-defined]
+            output_path = self._get_pagination_output_path(output_dir, page_num)
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
+            prev_url, next_url = self._pagination_prev_next(page_num, page_urls)
             context["prev_page_url"] = prev_url
             context["next_page_url"] = next_url
             context["pagination_page_urls"] = page_urls
             html = render_func(page_posts, page_num, total_pages)
-            self._write_html(output_path, html)  # type: ignore[attr-defined]
+            self._write_html(output_path, html)
 
-    def _generate_tag_pages(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_tag_pages(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate pages for each tag with pagination.
 
         Args:
@@ -87,7 +94,7 @@ class ListingMixin(DateArchivesMixin):
         """
         # Group posts by tag (case-insensitive)
         # Key is lowercase tag, value is (display_name, posts)
-        posts_by_tag = self._group_posts_by_tag(posts)  # type: ignore[attr-defined]
+        posts_by_tag = self._group_posts_by_tag(posts)
 
         # Create tag directory
         tag_dir = self.site_config.output_dir / TAG_DIR
@@ -105,7 +112,7 @@ class ListingMixin(DateArchivesMixin):
             # Each tag's pages live inside tag/{safe_tag}/ directory.
             tag_base_dir = tag_dir / safe_tag
 
-            context = self._get_global_context()  # type: ignore[attr-defined]
+            context = self._get_global_context()
             context["pages"] = pages
 
             # Default parameter values bind the current loop variables at
@@ -137,7 +144,9 @@ class ListingMixin(DateArchivesMixin):
                 render_func=_render_tag,
             )
 
-    def _generate_tags_page(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_tags_page(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate the tags overview page with word cloud.
 
         Args:
@@ -145,7 +154,7 @@ class ListingMixin(DateArchivesMixin):
             pages: All static pages, for sidebar navigation.
         """
         # Group posts by tag to get counts
-        posts_by_tag = self._group_posts_by_tag(posts)  # type: ignore[attr-defined]
+        posts_by_tag = self._group_posts_by_tag(posts)
 
         if not posts_by_tag:
             # No tags, skip generation
@@ -165,16 +174,16 @@ class ListingMixin(DateArchivesMixin):
         # Sort alphabetically by display name
         tag_data.sort(key=lambda x: x["display_name"].lower())
 
-        self._calculate_cloud_font_sizes(tag_data)  # type: ignore[attr-defined]
+        self._calculate_cloud_font_sizes(tag_data)
 
         # Render the tags page
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.tags_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        tags_url = self._get_tags_url()  # type: ignore[attr-defined]
+        tags_url = self._get_tags_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{tags_url}"
@@ -182,13 +191,15 @@ class ListingMixin(DateArchivesMixin):
                 else tags_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
 
         html = self.renderer.render_tags_page(tag_data, **context)
 
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
-    def _generate_categories_page(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_categories_page(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate the categories overview page with word cloud.
 
         Args:
@@ -196,7 +207,7 @@ class ListingMixin(DateArchivesMixin):
             pages: All static pages, for sidebar navigation.
         """
         # Group posts by category to get counts
-        posts_by_category = self._group_posts_by_category(posts)  # type: ignore[attr-defined]
+        posts_by_category = self._group_posts_by_category(posts)
 
         if not posts_by_category:
             # No categories, skip generation
@@ -219,16 +230,16 @@ class ListingMixin(DateArchivesMixin):
         # Sort alphabetically by display name
         category_data.sort(key=lambda x: x["display_name"].lower())
 
-        self._calculate_cloud_font_sizes(category_data)  # type: ignore[attr-defined]
+        self._calculate_cloud_font_sizes(category_data)
 
         # Render the categories page
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.categories_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        categories_url = self._get_categories_url()  # type: ignore[attr-defined]
+        categories_url = self._get_categories_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{categories_url}"
@@ -236,13 +247,15 @@ class ListingMixin(DateArchivesMixin):
                 else categories_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
 
         html = self.renderer.render_categories_page(category_data, **context)
 
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
-    def _generate_category_pages(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_category_pages(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate pages for each category with pagination.
 
         Args:
@@ -251,7 +264,7 @@ class ListingMixin(DateArchivesMixin):
         """
         # Group posts by category (case-insensitive)
         # Key is lowercase category, value is (display_name, posts)
-        posts_by_category = self._group_posts_by_category(posts)  # type: ignore[attr-defined]
+        posts_by_category = self._group_posts_by_category(posts)
 
         # Create category directory
         category_dir = self.site_config.output_dir / CATEGORY_DIR
@@ -272,7 +285,7 @@ class ListingMixin(DateArchivesMixin):
             # Each category's pages live inside category/{safe_category}/ directory.
             category_base_dir = category_dir / safe_category
 
-            context = self._get_global_context()  # type: ignore[attr-defined]
+            context = self._get_global_context()
             context["pages"] = pages
 
             def _render_category(

--- a/src/blogmore/generator/_listing.py
+++ b/src/blogmore/generator/_listing.py
@@ -12,8 +12,6 @@ from blogmore.generator._date_archives import DateArchivesMixin
 from blogmore.generator.constants import CATEGORY_DIR, TAG_DIR
 from blogmore.generator.utils import paginate_posts
 from blogmore.parser import Page, Post, post_sort_key, sanitize_for_url
-from blogmore.renderer import TemplateRenderer
-from blogmore.site_config import SiteConfig
 
 if TYPE_CHECKING:
     from blogmore.generator._protocol import GeneratorProtocol
@@ -23,21 +21,8 @@ class ListingMixin(DateArchivesMixin):
     """Mixin that generates paginated listing pages for archives, tags, and categories.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `renderer` ([`TemplateRenderer`][blogmore.renderer.TemplateRenderer])
-    - `POSTS_PER_PAGE_TAG` (`int`)
-    - `POSTS_PER_PAGE_CATEGORY` (`int`)
-    - `POSTS_PER_PAGE_ARCHIVE` (`int`)
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    POSTS_PER_PAGE_TAG: int
-    POSTS_PER_PAGE_CATEGORY: int
-    POSTS_PER_PAGE_ARCHIVE: int
 
     def _generate_paginated_listing(
         self: GeneratorProtocol,

--- a/src/blogmore/generator/_minify.py
+++ b/src/blogmore/generator/_minify.py
@@ -2,8 +2,11 @@
 [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
 """
 
+from __future__ import annotations
+
 from importlib.resources import files
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import minify_html
 import rcssmin  # type: ignore[import-untyped]
@@ -16,7 +19,9 @@ from blogmore.generator.constants import (
     CSS_FILENAME,
 )
 from blogmore.generator.utils import minified_filename
-from blogmore.site_config import SiteConfig
+
+if TYPE_CHECKING:
+    from blogmore.generator._protocol import GeneratorProtocol
 
 
 class MinifyMixin:
@@ -24,14 +29,10 @@ class MinifyMixin:
 
     This mixin is intended to be composed into
     [`SiteGenerator`][blogmore.generator.site.SiteGenerator] (via
-    [`AssetsMixin`][blogmore.generator._assets.AssetsMixin]).  It expects
-    the host class to provide a ``site_config`` attribute of type
-    [`SiteConfig`][blogmore.site_config.SiteConfig].
+    [`AssetsMixin`][blogmore.generator._assets.AssetsMixin]).
     """
 
-    site_config: SiteConfig
-
-    def _write_html(self, output_path: Path, html: str) -> None:
+    def _write_html(self: GeneratorProtocol, output_path: Path, html: str) -> None:
         """Write an HTML string to a file, minifying it when configured to do so.
 
         When ``minify_html`` is enabled the HTML content is passed through the
@@ -46,7 +47,7 @@ class MinifyMixin:
             html = minify_html.minify(html, minify_js=False, minify_css=False)
         output_path.write_text(html, encoding="utf-8")
 
-    def _get_asset_source(self, filename: str) -> str | None:
+    def _get_asset_source(self: GeneratorProtocol, filename: str) -> str | None:
         """Read the text content of a static asset, preferring custom over bundled.
 
         Looks first in the custom templates directory (``templates_dir/static/``)
@@ -72,7 +73,7 @@ class MinifyMixin:
             return None
 
     def _minify_one_css(
-        self,
+        self: GeneratorProtocol,
         output_static: Path,
         source_filename: str,
     ) -> None:
@@ -98,7 +99,7 @@ class MinifyMixin:
         output_path.write_text(minified, encoding="utf-8")
         print(f"Generated minified CSS as {minified_name}")
 
-    def _write_minified_css(self, output_static: Path) -> None:
+    def _write_minified_css(self: GeneratorProtocol, output_static: Path) -> None:
         """Minify all CSS files and write them to the output static directory.
 
         Minifies the main stylesheet (``style.css`` → ``style.min.css``) and
@@ -114,7 +115,7 @@ class MinifyMixin:
         for source_filename in _PAGE_SPECIFIC_CSS:
             self._minify_one_css(output_static, source_filename)
 
-    def _write_code_css(self, output_static: Path) -> None:
+    def _write_code_css(self: GeneratorProtocol, output_static: Path) -> None:
         """Generate and write the code syntax highlighting CSS file.
 
         Builds a ``code.css`` (or ``code.min.css`` when ``minify_css`` is
@@ -142,7 +143,9 @@ class MinifyMixin:
             output_path.write_text(css_content, encoding="utf-8")
             print(f"Generated code CSS as {CODE_CSS_FILENAME}")
 
-    def _write_minified_js(self, output_static: Path, js_filename: str) -> None:
+    def _write_minified_js(
+        self: GeneratorProtocol, output_static: Path, js_filename: str
+    ) -> None:
         """Read a source JavaScript file, minify it, and write it with the minified name.
 
         The source JS is read from the custom templates directory (if
@@ -165,7 +168,7 @@ class MinifyMixin:
         output_path.write_text(minified, encoding="utf-8")
         print(f"Generated minified JS as {js_min}")
 
-    def _write_fontawesome_css(self, css_content: str) -> None:
+    def _write_fontawesome_css(self: GeneratorProtocol, css_content: str) -> None:
         """Write the optimised FontAwesome CSS file to the static directory.
 
         Must be called *after*

--- a/src/blogmore/generator/_optional_pages.py
+++ b/src/blogmore/generator/_optional_pages.py
@@ -4,6 +4,10 @@
 Covers feeds, search, statistics, calendar, graph, and sitemap output.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from blogmore.backlinks import Backlink
 from blogmore.calendar import CalendarYear, build_calendar
 from blogmore.clean_url import make_url_clean
@@ -16,6 +20,9 @@ from blogmore.search import write_search_index
 from blogmore.site_config import SiteConfig
 from blogmore.sitemap import write_sitemap
 from blogmore.stats import BlogStats, compute_blog_stats
+
+if TYPE_CHECKING:
+    from blogmore.generator._protocol import GeneratorProtocol
 
 
 class OptionalPagesMixin:
@@ -35,7 +42,7 @@ class OptionalPagesMixin:
     renderer: TemplateRenderer
     _extras_html_paths: frozenset[str]
 
-    def _generate_feeds(self, posts: list[Post]) -> None:
+    def _generate_feeds(self: GeneratorProtocol, posts: list[Post]) -> None:
         """Generate RSS and Atom feeds.
 
         Args:
@@ -52,7 +59,7 @@ class OptionalPagesMixin:
         feed_gen.generate_index_feeds(posts)
 
         # Generate category feeds
-        posts_by_category = self._group_posts_by_category(posts)  # type: ignore[attr-defined]
+        posts_by_category = self._group_posts_by_category(posts)
         # Sort posts by date for each category
         for _category_lower, (
             _category_display,
@@ -70,19 +77,19 @@ class OptionalPagesMixin:
         """
         write_search_index(posts, self.site_config.output_dir)
 
-    def _generate_search_page(self, pages: list[Page]) -> None:
+    def _generate_search_page(self: GeneratorProtocol, pages: list[Page]) -> None:
         """Generate the search page.
 
         Args:
             pages: List of static pages (for the sidebar navigation).
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.search_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        search_url = self._get_search_url()  # type: ignore[attr-defined]
+        search_url = self._get_search_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{search_url}"
@@ -90,15 +97,15 @@ class OptionalPagesMixin:
                 else search_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         html = self.renderer.render_search_page(**context)
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _generate_stats_page(
-        self,
+        self: GeneratorProtocol,
         posts: list[Post],
         pages: list[Page],
-        backlink_map: "dict[str, list[Backlink]] | None" = None,
+        backlink_map: dict[str, list[Backlink]] | None = None,
     ) -> None:
         """Generate the blog statistics page.
 
@@ -109,13 +116,13 @@ class OptionalPagesMixin:
                 [`Backlink`][blogmore.backlinks.Backlink] objects.  When provided,
                 the statistics page includes a "Top Internal Links" section.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.stats_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        stats_url = self._get_stats_url()  # type: ignore[attr-defined]
+        stats_url = self._get_stats_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{stats_url}"
@@ -123,27 +130,29 @@ class OptionalPagesMixin:
                 else stats_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         blog_stats: BlogStats = compute_blog_stats(
             posts, self.site_config.site_url, backlink_map
         )
         html = self.renderer.render_stats_page(stats=blog_stats, **context)
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
-    def _generate_calendar_page(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_calendar_page(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate the calendar view page.
 
         Args:
             posts: All published posts; used to populate the calendar grid.
             pages: List of static pages (for the sidebar navigation).
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.calendar_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        calendar_url = self._get_calendar_url()  # type: ignore[attr-defined]
+        calendar_url = self._get_calendar_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{calendar_url}"
@@ -151,7 +160,7 @@ class OptionalPagesMixin:
                 else calendar_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         # Determine page1_suffix for archive URL construction.  When
         # clean_urls is enabled, strip any index filename (e.g. "index.html")
         # so that calendar links to year/month/day archives end with a
@@ -165,22 +174,24 @@ class OptionalPagesMixin:
         html = self.renderer.render_calendar_page(
             calendar_years=calendar_years, **context
         )
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
-    def _generate_graph_page(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_graph_page(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate the post-relationship graph page.
 
         Args:
             posts: All published posts; used to build graph nodes and edges.
             pages: List of static pages (for the sidebar navigation).
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.graph_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        graph_url = self._get_graph_url()  # type: ignore[attr-defined]
+        graph_url = self._get_graph_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{graph_url}"
@@ -188,7 +199,7 @@ class OptionalPagesMixin:
                 else graph_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         graph_data: GraphData = build_graph_data(
             posts,
             tag_dir=TAG_DIR,
@@ -198,7 +209,7 @@ class OptionalPagesMixin:
         html = self.renderer.render_graph_page(
             graph_data_json=graph_data.to_json(), **context
         )
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     def _remove_stale_search_files(self) -> None:
         """Remove search-related files left over from a previous build.
@@ -243,6 +254,3 @@ class OptionalPagesMixin:
             extra_excluded_paths=self._extras_html_paths,
             extra_urls=self.site_config.sitemap_extras,
         )
-
-
-### _optional_pages.py ends here

--- a/src/blogmore/generator/_optional_pages.py
+++ b/src/blogmore/generator/_optional_pages.py
@@ -15,9 +15,7 @@ from blogmore.feeds import BlogFeedGenerator
 from blogmore.generator.constants import CATEGORY_DIR, TAG_DIR
 from blogmore.graph import GraphData, build_graph_data
 from blogmore.parser import Page, Post, post_sort_key
-from blogmore.renderer import TemplateRenderer
 from blogmore.search import write_search_index
-from blogmore.site_config import SiteConfig
 from blogmore.sitemap import write_sitemap
 from blogmore.stats import BlogStats, compute_blog_stats
 
@@ -30,17 +28,8 @@ class OptionalPagesMixin:
 
     This mixin is intended to be composed into
     [`SiteGenerator`][blogmore.generator.site.SiteGenerator] via
-    [`PagesMixin`][blogmore.generator._pages.PagesMixin].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `renderer` ([`TemplateRenderer`][blogmore.renderer.TemplateRenderer])
-    - `_extras_html_paths` (`frozenset[str]`)
+    [`PagesMixin`][blogmore.generator._pages.PagesMixin].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    _extras_html_paths: frozenset[str]
 
     def _generate_feeds(self: GeneratorProtocol, posts: list[Post]) -> None:
         """Generate RSS and Atom feeds.
@@ -69,7 +58,7 @@ class OptionalPagesMixin:
 
         feed_gen.generate_category_feeds(posts_by_category)
 
-    def _generate_search_index(self, posts: list[Post]) -> None:
+    def _generate_search_index(self: GeneratorProtocol, posts: list[Post]) -> None:
         """Generate the search index JSON file.
 
         Args:
@@ -211,7 +200,7 @@ class OptionalPagesMixin:
         )
         self._write_html(output_path, html)
 
-    def _remove_stale_search_files(self) -> None:
+    def _remove_stale_search_files(self: GeneratorProtocol) -> None:
         """Remove search-related files left over from a previous build.
 
         When search is disabled, any search page (at the configured
@@ -238,7 +227,7 @@ class OptionalPagesMixin:
         if default_page.exists() and default_page != stale_page:
             default_page.unlink()
 
-    def _generate_sitemap(self) -> None:
+    def _generate_sitemap(self: GeneratorProtocol) -> None:
         """Generate the XML sitemap file.
 
         Writes ``sitemap.xml`` to the root of the output directory,

--- a/src/blogmore/generator/_pages.py
+++ b/src/blogmore/generator/_pages.py
@@ -2,7 +2,10 @@
 [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
 """
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from blogmore.backlinks import Backlink
 from blogmore.clean_url import make_url_clean
@@ -11,6 +14,9 @@ from blogmore.generator._optional_pages import OptionalPagesMixin
 from blogmore.parser import CUSTOM_404_HTML, Page, Post
 from blogmore.renderer import TemplateRenderer
 from blogmore.site_config import SiteConfig
+
+if TYPE_CHECKING:
+    from blogmore.generator._protocol import GeneratorProtocol
 
 
 class PagesMixin(OptionalPagesMixin):
@@ -32,12 +38,12 @@ class PagesMixin(OptionalPagesMixin):
     _extras_html_paths: frozenset[str]
 
     def _generate_post_page(
-        self,
+        self: GeneratorProtocol,
         post: Post,
         all_posts: list[Post],
         pages: list[Page],
         output_path: Path,
-        backlinks_map: "dict[str, list[Backlink]] | None" = None,
+        backlinks_map: dict[str, list[Backlink]] | None = None,
     ) -> None:
         """Generate a single post page.
 
@@ -51,7 +57,7 @@ class PagesMixin(OptionalPagesMixin):
                 ``None`` or when the post URL has no entry, an empty list is
                 used so the template always receives a ``backlinks`` variable.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["all_posts"] = all_posts
         context["pages"] = pages
 
@@ -97,11 +103,13 @@ class PagesMixin(OptionalPagesMixin):
                 else post.url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         html = self.renderer.render_post(post, **context)
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
-    def _generate_page(self, page: Page, pages: list[Page], output_path: Path) -> None:
+    def _generate_page(
+        self: GeneratorProtocol, page: Page, pages: list[Page], output_path: Path
+    ) -> None:
         """Generate a single static page.
 
         Args:
@@ -109,34 +117,38 @@ class PagesMixin(OptionalPagesMixin):
             pages: All static pages, passed to the template context.
             output_path: The pre-resolved absolute output file path for this page.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+        context["canonical_url"] = self._canonical_url_for_path(output_path)
 
         html = self.renderer.render_page(page, **context)
 
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
-    def _generate_404_page(self, page: Page, pages: list[Page]) -> None:
+    def _generate_404_page(
+        self: GeneratorProtocol, page: Page, pages: list[Page]
+    ) -> None:
         """Generate the custom 404 page in the root of the output directory.
 
         Args:
             page: The 404 page content to render.
             pages: All static pages, passed to the template context.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = self.site_config.output_dir / CUSTOM_404_HTML
-        context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+        context["canonical_url"] = self._canonical_url_for_path(output_path)
 
         html = self.renderer.render_page(page, **context)
 
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
-    def _generate_index_page(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_index_page(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate the main index page with pagination.
 
         Page 1 of the main index is always written to ``index.html`` at the
@@ -152,7 +164,7 @@ class PagesMixin(OptionalPagesMixin):
         """
         from blogmore.generator.utils import paginate_posts
 
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
 
         # Paginate posts
@@ -168,7 +180,7 @@ class PagesMixin(OptionalPagesMixin):
         if self.site_config.clean_urls:
             page1_url = make_url_clean(page1_url)
         page_urls = [page1_url] + [
-            self._get_pagination_url("", page_num)  # type: ignore[attr-defined]
+            self._get_pagination_url("", page_num)
             for page_num in range(2, total_pages + 1)
         ]
 
@@ -178,11 +190,11 @@ class PagesMixin(OptionalPagesMixin):
                 output_path = self.site_config.output_dir / "index.html"
                 output_path.parent.mkdir(parents=True, exist_ok=True)
             else:
-                output_path = self._get_pagination_output_path(  # type: ignore[attr-defined]
+                output_path = self._get_pagination_output_path(
                     self.site_config.output_dir, page_num
                 )
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
-            prev_url, next_url = self._pagination_prev_next(page_num, page_urls)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
+            prev_url, next_url = self._pagination_prev_next(page_num, page_urls)
             context["prev_page_url"] = prev_url
             context["next_page_url"] = next_url
             context["pagination_page_urls"] = page_urls
@@ -190,22 +202,24 @@ class PagesMixin(OptionalPagesMixin):
                 page_posts, page=page_num, total_pages=total_pages, **context
             )
 
-            self._write_html(output_path, html)  # type: ignore[attr-defined]
+            self._write_html(output_path, html)
 
-    def _generate_archive_page(self, posts: list[Post], pages: list[Page]) -> None:
+    def _generate_archive_page(
+        self: GeneratorProtocol, posts: list[Post], pages: list[Page]
+    ) -> None:
         """Generate the archive page.
 
         Args:
             posts: All published posts.
             pages: All static pages, for sidebar navigation.
         """
-        context = self._get_global_context()  # type: ignore[attr-defined]
+        context = self._get_global_context()
         context["pages"] = pages
         output_path = (
             self.site_config.output_dir / self.site_config.archive_path.lstrip("/")
         ).resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        archive_url = self._get_archive_url()  # type: ignore[attr-defined]
+        archive_url = self._get_archive_url()
         if self.site_config.clean_urls:
             context["canonical_url"] = (
                 f"{self.site_config.site_url}{archive_url}"
@@ -213,10 +227,10 @@ class PagesMixin(OptionalPagesMixin):
                 else archive_url
             )
         else:
-            context["canonical_url"] = self._canonical_url_for_path(output_path)  # type: ignore[attr-defined]
+            context["canonical_url"] = self._canonical_url_for_path(output_path)
         html = self.renderer.render_archive(
             posts, page=1, total_pages=1, base_path="/archive", **context
         )
-        self._write_html(output_path, html)  # type: ignore[attr-defined]
+        self._write_html(output_path, html)
 
     ### _pages.py ends here

--- a/src/blogmore/generator/_pages.py
+++ b/src/blogmore/generator/_pages.py
@@ -12,8 +12,6 @@ from blogmore.clean_url import make_url_clean
 from blogmore.comment_invite import build_mailto_url, get_invite_email_for_post
 from blogmore.generator._optional_pages import OptionalPagesMixin
 from blogmore.parser import CUSTOM_404_HTML, Page, Post
-from blogmore.renderer import TemplateRenderer
-from blogmore.site_config import SiteConfig
 
 if TYPE_CHECKING:
     from blogmore.generator._protocol import GeneratorProtocol
@@ -23,19 +21,8 @@ class PagesMixin(OptionalPagesMixin):
     """Mixin that generates each type of HTML page written to the output directory.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide the following instance attributes:
-
-    - `site_config` ([`SiteConfig`][blogmore.site_config.SiteConfig])
-    - `renderer` ([`TemplateRenderer`][blogmore.renderer.TemplateRenderer])
-    - `POSTS_PER_PAGE_INDEX` (`int`)
-    - `_extras_html_paths` (`frozenset[str]`)
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
-
-    site_config: SiteConfig
-    renderer: TemplateRenderer
-    POSTS_PER_PAGE_INDEX: int
-    _extras_html_paths: frozenset[str]
 
     def _generate_post_page(
         self: GeneratorProtocol,

--- a/src/blogmore/generator/_paths.py
+++ b/src/blogmore/generator/_paths.py
@@ -2,29 +2,32 @@
 [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from blogmore.clean_url import make_url_clean
 from blogmore.page_path import compute_page_output_path
 from blogmore.pagination_path import resolve_pagination_page_path
 from blogmore.parser import Page, Post
 from blogmore.post_path import compute_output_path
-from blogmore.site_config import SiteConfig
+
+if TYPE_CHECKING:
+    from blogmore.generator._protocol import GeneratorProtocol
 
 
 class PathsMixin:
     """Mixin that resolves pagination paths, canonical URLs, and output paths.
 
     This mixin is intended to be composed into
-    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].  It expects
-    the host class to provide a ``site_config`` attribute of type
-    [`SiteConfig`][blogmore.site_config.SiteConfig].
+    [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
     """
 
-    site_config: SiteConfig
-
-    def _get_pagination_url(self, base_url: str, page_num: int) -> str:
+    def _get_pagination_url(
+        self: GeneratorProtocol, base_url: str, page_num: int
+    ) -> str:
         """Compute the URL for a given pagination page.
 
         Joins *base_url* with the path resolved from the configured
@@ -54,7 +57,9 @@ class PathsMixin:
             url = make_url_clean(url)
         return url
 
-    def _build_pagination_page_urls(self, base_url: str, total_pages: int) -> list[str]:
+    def _build_pagination_page_urls(
+        self: GeneratorProtocol, base_url: str, total_pages: int
+    ) -> list[str]:
         """Build the full list of page URLs for a paginated section.
 
         Args:
@@ -70,7 +75,9 @@ class PathsMixin:
             for page_num in range(1, total_pages + 1)
         ]
 
-    def _get_pagination_output_path(self, base_dir: Path, page_num: int) -> Path:
+    def _get_pagination_output_path(
+        self: GeneratorProtocol, base_dir: Path, page_num: int
+    ) -> Path:
         """Compute the output file path for a given pagination page.
 
         Resolves the appropriate path template from the site configuration
@@ -115,7 +122,7 @@ class PathsMixin:
         )
         return prev_url, next_url
 
-    def _canonical_url_for_path(self, output_path: Path) -> str:
+    def _canonical_url_for_path(self: GeneratorProtocol, output_path: Path) -> str:
         """Compute the fully-qualified canonical URL for a given output file path.
 
         When ``clean_urls`` is enabled, index filenames (e.g. ``index.html``)
@@ -135,7 +142,9 @@ class PathsMixin:
             url = make_url_clean(url)
         return f"{self.site_config.site_url}{url}"
 
-    def _resolve_post_output_paths(self, posts: list[Post]) -> dict[int, Path]:
+    def _resolve_post_output_paths(
+        self: GeneratorProtocol, posts: list[Post]
+    ) -> dict[int, Path]:
         """Resolve the output path for every post and detect path clashes.
 
         For each post the method:
@@ -197,7 +206,9 @@ class PathsMixin:
 
         return post_output_paths
 
-    def _resolve_page_output_paths(self, pages: list[Page]) -> dict[int, Path]:
+    def _resolve_page_output_paths(
+        self: GeneratorProtocol, pages: list[Page]
+    ) -> dict[int, Path]:
         """Resolve the output path for every static page.
 
         For each page the method:
@@ -234,7 +245,9 @@ class PathsMixin:
 
         return page_output_paths
 
-    def _resolve_sidebar_pages(self, pages: list[Page]) -> list[Page]:
+    def _resolve_sidebar_pages(
+        self: GeneratorProtocol, pages: list[Page]
+    ) -> list[Page]:
         """Resolve which pages appear in the sidebar and in what order.
 
         When ``site_config.sidebar_pages`` is ``None`` or empty every page in

--- a/src/blogmore/generator/_protocol.py
+++ b/src/blogmore/generator/_protocol.py
@@ -40,6 +40,9 @@ class GeneratorProtocol(Protocol):
     POSTS_PER_PAGE_CATEGORY: int
     POSTS_PER_PAGE_ARCHIVE: int
 
+    @property
+    def _content_dir(self) -> Path: ...
+
     def _with_cache_bust(self, url: str) -> str: ...
 
     def _get_asset_url(
@@ -70,6 +73,8 @@ class GeneratorProtocol(Protocol):
 
     def _get_graph_url(self) -> str: ...
 
+    def _get_configured_url(self, path_field_name: str) -> str: ...
+
     def _get_pagination_url(self, base_url: str, page_num: int) -> str: ...
 
     def _build_pagination_page_urls(
@@ -87,6 +92,20 @@ class GeneratorProtocol(Protocol):
     def _canonical_url_for_path(self, output_path: Path) -> str: ...
 
     def _write_html(self, output_path: Path, html: str) -> None: ...
+
+    def _get_asset_source(self, filename: str) -> str | None: ...
+
+    def _minify_one_css(
+        self,
+        output_static: Path,
+        source_filename: str,
+    ) -> None: ...
+
+    def _write_minified_css(self, output_static: Path) -> None: ...
+
+    def _write_code_css(self, output_static: Path) -> None: ...
+
+    def _write_minified_js(self, output_static: Path, js_filename: str) -> None: ...
 
     def _generate_paginated_listing(
         self,

--- a/src/blogmore/generator/_protocol.py
+++ b/src/blogmore/generator/_protocol.py
@@ -1,0 +1,114 @@
+"""Protocol defining the interface for the site generator.
+
+This module provides a [`GeneratorProtocol`][blogmore.generator._protocol.GeneratorProtocol]
+that describes the combined interface of all generator mixins.  It is used
+to provide type safety for cross-mixin method calls without requiring
+circular imports or ``type: ignore`` pragmas.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from blogmore.parser import Post
+    from blogmore.renderer import TemplateRenderer
+    from blogmore.site_config import SiteConfig
+
+
+class GeneratorProtocol(Protocol):
+    """Protocol describing the full interface of the [`SiteGenerator`][blogmore.generator.site.SiteGenerator].
+
+    This protocol includes all attributes and methods provided by the various
+    generator mixins ([`AssetsMixin`][blogmore.generator._assets.AssetsMixin],
+    [`ContextMixin`][blogmore.generator._context.ContextMixin], etc.) and is
+    used to type the ``self`` argument in mixin methods that call methods
+    defined in other mixins.
+    """
+
+    site_config: SiteConfig
+    renderer: TemplateRenderer
+    _fontawesome_css_url: str
+    _cache_bust_token: str
+    _extras_html_paths: frozenset[str]
+
+    # Pagination constants
+    POSTS_PER_PAGE_INDEX: int
+    POSTS_PER_PAGE_TAG: int
+    POSTS_PER_PAGE_CATEGORY: int
+    POSTS_PER_PAGE_ARCHIVE: int
+
+    def _with_cache_bust(self, url: str) -> str: ...
+
+    def _get_asset_url(
+        self,
+        regular: str,
+        minify: bool,
+        *,
+        cache_bust: bool = True,
+    ) -> str: ...
+
+    def _get_global_context(self) -> dict[str, Any]: ...
+
+    def _detect_favicon(self) -> str | None: ...
+
+    def _detect_generated_icons(self) -> bool: ...
+
+    def _get_search_url(self) -> str: ...
+
+    def _get_archive_url(self) -> str: ...
+
+    def _get_tags_url(self) -> str: ...
+
+    def _get_categories_url(self) -> str: ...
+
+    def _get_stats_url(self) -> str: ...
+
+    def _get_calendar_url(self) -> str: ...
+
+    def _get_graph_url(self) -> str: ...
+
+    def _get_pagination_url(self, base_url: str, page_num: int) -> str: ...
+
+    def _build_pagination_page_urls(
+        self, base_url: str, total_pages: int
+    ) -> list[str]: ...
+
+    def _get_pagination_output_path(self, base_dir: Path, page_num: int) -> Path: ...
+
+    def _pagination_prev_next(
+        self,
+        page_num: int,
+        page_urls: list[str],
+    ) -> tuple[str | None, str | None]: ...
+
+    def _canonical_url_for_path(self, output_path: Path) -> str: ...
+
+    def _write_html(self, output_path: Path, html: str) -> None: ...
+
+    def _generate_paginated_listing(
+        self,
+        post_list: list[Post],
+        base_url: str,
+        output_dir: Path,
+        posts_per_page: int,
+        context: dict[str, Any],
+        render_func: Callable[[list[Post], int, int], str],
+    ) -> None: ...
+
+    def _group_posts_by_tag(
+        self, posts: list[Post]
+    ) -> dict[str, tuple[str, list[Post]]]: ...
+
+    def _group_posts_by_category(
+        self, posts: list[Post]
+    ) -> dict[str, tuple[str, list[Post]]]: ...
+
+    def _calculate_cloud_font_sizes(
+        self,
+        data: list[dict[str, Any]],
+        min_size: float = 1.0,
+        max_size: float = 2.5,
+    ) -> None: ...


### PR DESCRIPTION
Prompt was:

> Within @src/blogmore/generator/ there is a lot of `type: ignore[attr-defined]`. This seems to be down to the current mixin implementation. I'm happy with the use of mixins, but I'd like for this to be done in a way where we don't have to use pragmas that ignore type checking. Propose a way that this can be cleaned up.
>
> Be sure to take the contents of @AGENTS.md into account, so that you fully undersatnd the project's standards and current layout.

In respect to #447.

https://blog.davep.org/2026/05/04/i-wouldnt-start-from-here.html