### PR TITLE
Cache the FontAwesome metadata

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # BlogMore ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- The FontAwesome metadata is now cached, saving the need to download it
+  every time a site is built.
+
 ## v2.21.0
 
 **Released: 2026-05-10**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 - The FontAwesome metadata is now cached, saving the need to download it
   every time a site is built.
+  ([#469](https://github.com/davep/blogmore/pull/469))
 
 ## v2.21.0
 

--- a/src/blogmore/fontawesome.py
+++ b/src/blogmore/fontawesome.py
@@ -11,6 +11,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from blogmore.utils import get_user_cache_dir
+
 # FontAwesome version targeted by this optimizer
 FONTAWESOME_VERSION = "6.5.1"
 
@@ -72,7 +74,11 @@ class FontAwesomeOptimizer:
         self.icon_names = icon_names
 
     def fetch_icon_metadata(self) -> dict[str, Any]:
-        """Fetch FontAwesome icon metadata from GitHub.
+        """Fetch FontAwesome icon metadata with local caching.
+
+        Attempts to load metadata from a local cache file first. If the file
+        does not exist or is corrupt, it fetches the metadata from GitHub
+        and updates the cache.
 
         Returns:
             Dictionary mapping icon name to its metadata (including the
@@ -80,11 +86,34 @@ class FontAwesomeOptimizer:
 
         Raises:
             urllib.error.URLError: If the metadata cannot be fetched from
-                GitHub.
+                GitHub and no cache is available.
             ValueError: If the response cannot be parsed as JSON.
         """
+        cache_dir = get_user_cache_dir()
+        cache_file = cache_dir / f"fa-metadata-{FONTAWESOME_VERSION}.json"
+
+        # Try to load from cache first
+        if cache_file.exists():
+            try:
+                return dict(json.loads(cache_file.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                # If cache is corrupt, we'll fall through to network fetch
+                pass
+
+        # Network fetch
         with urllib.request.urlopen(FONTAWESOME_METADATA_URL) as response:
-            return dict(json.loads(response.read().decode("utf-8")))
+            content = response.read().decode("utf-8")
+
+        # Update cache
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_file.write_text(content, encoding="utf-8")
+        except OSError:
+            # If we can't write the cache, we still return the fetched data
+            # to avoid failing the build.
+            pass
+
+        return dict(json.loads(content))
 
     def build_css(self, metadata: dict[str, Any]) -> str:
         """Build a minimal CSS string for only the requested brand icons.

--- a/src/blogmore/utils.py
+++ b/src/blogmore/utils.py
@@ -1,8 +1,30 @@
 """Utility functions for blogmore."""
 
+import os
 import re
+import sys
+from pathlib import Path
 
 from blogmore.markdown.plain_text import markdown_to_plain_text
+
+
+def get_user_cache_dir() -> Path:
+    """Return the platform-specific user cache directory for blogmore.
+
+    On Windows, this uses %LOCALAPPDATA%. On all other platforms (Unix/macOS),
+    it follows the XDG Base Directory Specification (~/.cache).
+
+    Returns:
+        A Path object pointing to the user's cache directory for blogmore.
+    """
+    if sys.platform == "win32":
+        # Windows: %LOCALAPPDATA%\blogmore\cache
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / "blogmore" / "cache"
+
+    # Unix-like (Linux, macOS, etc.): ~/.cache/blogmore or $XDG_CACHE_HOME/blogmore
+    base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return base / "blogmore"
 
 
 def count_words(content: str) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,27 @@
 
 import datetime as dt
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from blogmore.parser import Page, Post
+
+
+@pytest.fixture(autouse=True)
+def mock_user_cache_dir(tmp_path: Path):
+    """Automatically mock the user cache directory for all tests.
+
+    This prevents tests from ever touching the real user's cache directory
+    on the filesystem.
+    """
+    test_cache = tmp_path / "blogmore_test_cache"
+    test_cache.mkdir(parents=True, exist_ok=True)
+    with (
+        patch("blogmore.utils.get_user_cache_dir", return_value=test_cache),
+        patch("blogmore.fontawesome.get_user_cache_dir", return_value=test_cache),
+    ):
+        yield test_cache
 
 
 @pytest.fixture

--- a/tests/test_fontawesome.py
+++ b/tests/test_fontawesome.py
@@ -188,17 +188,18 @@ class TestFontAwesomeOptimizerFetchIconMetadata:
         assert isinstance(result, dict)
         assert "github" in result
 
-    def test_fetch_raises_on_network_error(self) -> None:
+    def test_fetch_raises_on_network_error(self, tmp_path: Path) -> None:
         """Test that fetch_icon_metadata propagates URL errors."""
         import urllib.error
 
-        with patch(
-            "urllib.request.urlopen",
-            side_effect=urllib.error.URLError("network error"),
-        ):
-            optimizer = FontAwesomeOptimizer(["github"])
-            with pytest.raises(urllib.error.URLError):
-                optimizer.fetch_icon_metadata()
+        with patch("blogmore.fontawesome.get_user_cache_dir", return_value=tmp_path):
+            with patch(
+                "urllib.request.urlopen",
+                side_effect=urllib.error.URLError("network error"),
+            ):
+                optimizer = FontAwesomeOptimizer(["github"])
+                with pytest.raises(urllib.error.URLError):
+                    optimizer.fetch_icon_metadata()
 
 
 class TestFontAwesomeOptimizerGenerate:

--- a/tests/test_fontawesome.py
+++ b/tests/test_fontawesome.py
@@ -170,7 +170,7 @@ class TestFontAwesomeOptimizerBuildCss:
 class TestFontAwesomeOptimizerFetchIconMetadata:
     """Test FontAwesomeOptimizer.fetch_icon_metadata."""
 
-    def test_fetch_returns_dict_on_success(self) -> None:
+    def test_fetch_returns_dict_on_success(self, tmp_path: Path) -> None:
         """Test that fetch_icon_metadata returns a dict when the request succeeds."""
         import json
 
@@ -181,9 +181,10 @@ class TestFontAwesomeOptimizerFetchIconMetadata:
         mock_cm.__enter__.return_value = mock_response
         mock_cm.__exit__.return_value = False
 
-        with patch("urllib.request.urlopen", return_value=mock_cm):
-            optimizer = FontAwesomeOptimizer(["github"])
-            result = optimizer.fetch_icon_metadata()
+        with patch("blogmore.fontawesome.get_user_cache_dir", return_value=tmp_path):
+            with patch("urllib.request.urlopen", return_value=mock_cm):
+                optimizer = FontAwesomeOptimizer(["github"])
+                result = optimizer.fetch_icon_metadata()
 
         assert isinstance(result, dict)
         assert "github" in result

--- a/tests/test_fontawesome_cache.py
+++ b/tests/test_fontawesome_cache.py
@@ -1,0 +1,98 @@
+"""Unit tests for FontAwesome metadata caching."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from blogmore.fontawesome import FONTAWESOME_METADATA_URL, FontAwesomeOptimizer
+
+STUB_METADATA = {"github": {"unicode": "f09b"}}
+
+
+class TestFontAwesomeCaching:
+    """Test the caching logic in FontAwesomeOptimizer.fetch_icon_metadata."""
+
+    @pytest.fixture
+    def mock_cache_dir(self, tmp_path):
+        """Mock the cache directory using a temporary path."""
+        with patch("blogmore.fontawesome.get_user_cache_dir", return_value=tmp_path):
+            yield tmp_path
+
+    def test_fetch_uses_cache_when_available(self, mock_cache_dir):
+        """Test that metadata is loaded from cache if the file exists."""
+        cache_file = mock_cache_dir / "fa-metadata-6.5.1.json"
+        cache_file.write_text(json.dumps(STUB_METADATA))
+
+        optimizer = FontAwesomeOptimizer(["github"])
+
+        # Patch urlopen to ensure it's NOT called
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            metadata = optimizer.fetch_icon_metadata()
+            mock_urlopen.assert_not_called()
+
+        assert metadata == STUB_METADATA
+
+    def test_fetch_updates_cache_on_miss(self, mock_cache_dir):
+        """Test that metadata is fetched and saved to cache on a miss."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(STUB_METADATA).encode("utf-8")
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = mock_response
+
+        optimizer = FontAwesomeOptimizer(["github"])
+
+        with patch("urllib.request.urlopen", return_value=mock_cm) as mock_urlopen:
+            metadata = optimizer.fetch_icon_metadata()
+            mock_urlopen.assert_called_once_with(FONTAWESOME_METADATA_URL)
+
+        assert metadata == STUB_METADATA
+
+        # Verify cache file was created
+        cache_file = mock_cache_dir / "fa-metadata-6.5.1.json"
+        assert cache_file.exists()
+        assert json.loads(cache_file.read_text()) == STUB_METADATA
+
+    def test_fetch_falls_back_on_corrupt_cache(self, mock_cache_dir):
+        """Test that corrupt cache is ignored and metadata is re-fetched."""
+        cache_file = mock_cache_dir / "fa-metadata-6.5.1.json"
+        cache_file.write_text("invalid json")
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(STUB_METADATA).encode("utf-8")
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = mock_response
+
+        optimizer = FontAwesomeOptimizer(["github"])
+
+        with patch("urllib.request.urlopen", return_value=mock_cm) as mock_urlopen:
+            metadata = optimizer.fetch_icon_metadata()
+            mock_urlopen.assert_called_once()
+
+        assert metadata == STUB_METADATA
+        # Cache should have been updated with valid data
+        assert json.loads(cache_file.read_text()) == STUB_METADATA
+
+    def test_fetch_works_if_cache_cannot_be_written(self, tmp_path):
+        """Test that fetch succeeds even if the cache directory is read-only."""
+        # Create a read-only directory
+        cache_dir = tmp_path / "readonly_cache"
+        cache_dir.mkdir()
+        # On some systems, making it read-only might not prevent file creation
+        # depending on parent permissions, but we can mock mkdir to fail.
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(STUB_METADATA).encode("utf-8")
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = mock_response
+
+        with patch("blogmore.fontawesome.get_user_cache_dir", return_value=cache_dir):
+            # Mock mkdir to simulate permission error
+            with patch("pathlib.Path.mkdir", side_effect=OSError("Permission denied")):
+                optimizer = FontAwesomeOptimizer(["github"])
+                with patch("urllib.request.urlopen", return_value=mock_cm):
+                    metadata = optimizer.fetch_icon_metadata()
+
+        assert metadata == STUB_METADATA
+        # No cache file should have been created (or at least we didn't crash)


### PR DESCRIPTION
Remove some of the delay in the build process by keeping a cache of the fontawesome metadata.