### PR TITLE
Fix backlink markers leaking into backlink display/content

### DIFF
--- a/src/blogmore/backlinks.py
+++ b/src/blogmore/backlinks.py
@@ -95,12 +95,25 @@ def _extract_snippets(
         marker = f"{_BACKLINK_MARKER_PREFIX}{i}_"
         marked_content = marked_content[:start] + marker + marked_content[end:]
 
+    # Pre-calculate the plain-text representation of every link's text.
+    # This allows us to replace secondary markers in snippets without
+    # redundant Markdown parses.
+    plain_link_texts = [
+        markdown_to_plain_text(lt) if lt else "" for _, _, lt, _ in sorted_links
+    ]
+
     # Convert the entire marked document to plain text in one pass
     plain_full = markdown_to_plain_text(marked_content)
 
+    # Locate the spans of all markers in the plain text. We will use these
+    # to "snap" the context window boundaries so that we never extract
+    # a partial marker.
+    marker_pattern = re.escape(_BACKLINK_MARKER_PREFIX) + r"\d+_"
+    marker_spans = [m.span() for m in re.finditer(marker_pattern, plain_full)]
+
     results: list[tuple[Post, Markup]] = []
     # Process links in original sorted order (which corresponds to markers 0, 1, 2...)
-    for i, (_, _, link_text, target_post) in enumerate(sorted_links):
+    for i, (_, _, _, target_post) in enumerate(sorted_links):
         marker = f"{_BACKLINK_MARKER_PREFIX}{i}_"
         marker_pos = plain_full.find(marker)
         if marker_pos == -1:
@@ -109,6 +122,18 @@ def _extract_snippets(
         marker_end_pos = marker_pos + len(marker)
         context_start = max(0, marker_pos - _SNIPPET_CONTEXT_CHARS)
         context_end = min(len(plain_full), marker_end_pos + _SNIPPET_CONTEXT_CHARS)
+
+        # Snap boundaries to avoid cutting through any marker.
+        for ms_start, ms_end in marker_spans:
+            if ms_start < context_start < ms_end:
+                # context_start is inside a marker; snap to the end of it
+                # to exclude the partial marker from the snippet.
+                context_start = ms_end
+            if ms_start < context_end < ms_end:
+                # context_end is inside a marker; snap to the start of it
+                # to exclude the partial marker from the snippet.
+                context_end = ms_start
+
         excerpt = plain_full[context_start:context_end]
 
         prefix = "…" if context_start > 0 else ""
@@ -117,8 +142,9 @@ def _extract_snippets(
         # HTML-escape the whole plain-text snippet.
         escaped: Markup = Markup.escape(f"{prefix}{excerpt}{suffix}")
 
-        # Replace the marker with the highlighted link text.
-        plain_link_text = markdown_to_plain_text(link_text) if link_text else ""
+        # 1. Replace the "main" marker (the one for this backlink) with the
+        # highlighted link text.
+        plain_link_text = plain_link_texts[i]
         if plain_link_text:
             escaped_link_text = Markup.escape(plain_link_text)
             highlighted = Markup(
@@ -127,6 +153,15 @@ def _extract_snippets(
             escaped = Markup(escaped.replace(marker, highlighted, 1))
         else:
             escaped = Markup(escaped.replace(marker, Markup(""), 1))
+
+        # 2. Replace any other markers that fell into this excerpt window
+        # with their plain-text link text.
+        def _replace_secondary(match: re.Match[str]) -> str:
+            other_index = int(match.group(1))
+            return str(Markup.escape(plain_link_texts[other_index]))
+
+        secondary_pattern = re.escape(_BACKLINK_MARKER_PREFIX) + r"(\d+)_"
+        escaped = Markup(re.sub(secondary_pattern, _replace_secondary, str(escaped)))
 
         results.append((target_post, escaped))
 

--- a/tests/test_backlinks.py
+++ b/tests/test_backlinks.py
@@ -373,6 +373,71 @@ class TestExtractSnippet:
         snippet = _extract_single_snippet(content, m.start(), m.end())
         assert isinstance(snippet, Markup)
 
+    def test_multiple_links_in_snippet_no_marker_leakage(self) -> None:
+        """Other markers in a snippet window are replaced by their plain-text link text."""
+        content = (
+            "First [Link 1](/1.html) then [Link 2](/2.html) "
+            "then [Link 3](/3.html) then more."
+        )
+        post1 = _make_post("post1", "Post 1", "/1.html")
+        post2 = _make_post("post2", "Post 2", "/2.html")
+        post3 = _make_post("post3", "Post 3", "/3.html")
+
+        # Find all link positions
+        link1_m = re.search(r"\[Link 1\]\(/1\.html\)", content)
+        link2_m = re.search(r"\[Link 2\]\(/2\.html\)", content)
+        link3_m = re.search(r"\[Link 3\]\(/3\.html\)", content)
+        assert link1_m and link2_m and link3_m
+
+        link_data = [
+            (link1_m.start(), link1_m.end(), "Link 1", post1),
+            (link2_m.start(), link2_m.end(), "Link 2", post2),
+            (link3_m.start(), link3_m.end(), "Link 3", post3),
+        ]
+
+        results = _extract_snippets(content, link_data)
+
+        # Snippet for link 2
+        snippet2 = results[1][1]
+        # Link 2 itself must be highlighted
+        assert '<strong class="backlink-link-text">Link 2</strong>' in snippet2
+        # Link 1 and Link 3 are nearby and their markers must be replaced
+        # by their plain-text versions.
+        assert "Link 1" in snippet2
+        assert "Link 3" in snippet2
+        # No raw BKLINK markers should remain
+        assert "BKLINK" not in str(snippet2)
+
+    def test_marker_at_context_boundary_is_snapped_out(self) -> None:
+        """A marker that would be truncated at a context boundary is snapped out of the snippet."""
+        # _SNIPPET_CONTEXT_CHARS is 100.
+        # Link 1 is the main link.
+        # Link 2 is placed so its marker would be partially inside the 100-char window.
+        padding = "a" * 95
+        content = f"[Link 1](/1.html) {padding} [Link 2](/2.html)"
+
+        post1 = _make_post("post1", "Post 1", "/1.html")
+        post2 = _make_post("post2", "Post 2", "/2.html")
+
+        link1_m = re.search(r"\[Link 1\]\(/1\.html\)", content)
+        link2_m = re.search(r"\[Link 2\]\(/2\.html\)", content)
+        assert link1_m and link2_m
+
+        link_data = [
+            (link1_m.start(), link1_m.end(), "Link 1", post1),
+            (link2_m.start(), link2_m.end(), "Link 2", post2),
+        ]
+
+        results = _extract_snippets(content, link_data)
+        # Results are in reverse order of position (matches sorted_links)
+        # Link 1 (start 0) is index 1.
+        snippet1 = str(results[1][1])
+
+        # Because context_end is snapped to ms_start when it falls inside a marker,
+        # the truncated Link 2 marker is excluded.
+        assert "Link 2" not in snippet1
+        assert "BKLINK" not in snippet1
+
 
 ##############################################################################
 # build_backlink_map tests.


### PR DESCRIPTION
The work in #470 introduced a bug, where the link markers were leaking into the context window when displaying a backlink:

<img width="775" height="140" alt="Screenshot 2026-05-11 at 19 17 29" src="https://github.com/user-attachments/assets/705d872e-7aae-4db2-adb8-88ffac6627bf" />

when the above should look like this:

<img width="773" height="134" alt="Screenshot 2026-05-11 at 19 17 41" src="https://github.com/user-attachments/assets/c218ef2f-bc9b-4241-8b3c-3aac50643266" />

This is a fix for the issue.