### PR TITLE
The need for more speed (AKA more PageSpeed Insights validation chasing)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,15 @@
 - Fixed HTML entities being incorrectly included in their escaped form (like
   `&quot;` and `&gt;`) in the search index snippets.
   ([#497](https://github.com/davep/blogmore/pull/497))
+- Added support for optionally bundling the main CSS files into a single
+  file, to help speed up the first load from a site (controlled by
+  `bundle_css` and off by default).
+  ([#499](https://github.com/davep/blogmore/pull/499))
+- Added support for optionally inlining the main theming JavaScript code
+  into every generated page, giving the option to reduce the number of
+  JavaScript files that need to be downloaded on the first load of a site
+  (controlled by `inline_theme_js` and off by default).
+  ([#499](https://github.com/davep/blogmore/pull/499))
 
 ## v2.24.0
 

--- a/THEME_DEVELOPMENT_GUIDELINES.md
+++ b/THEME_DEVELOPMENT_GUIDELINES.md
@@ -137,6 +137,7 @@ v2.x.  Key ones that appear in nearly every template:
 - `pages` — sorted list of `Page` objects
 - `prev_page_url`, `next_page_url` — pagination URLs (may be `None`)
 - `canonical_url`
+- `bundle_css`, `bundle_css_url`, `fontawesome_is_bundled` — for CSS bundling support
 
 ### Stable Post attributes
 

--- a/THEME_DEVELOPMENT_GUIDELINES.md
+++ b/THEME_DEVELOPMENT_GUIDELINES.md
@@ -138,6 +138,7 @@ v2.x.  Key ones that appear in nearly every template:
 - `prev_page_url`, `next_page_url` — pagination URLs (may be `None`)
 - `canonical_url`
 - `bundle_css`, `bundle_css_url`, `fontawesome_is_bundled` — for CSS bundling support
+- `inline_theme_js`, `theme_js_content` — for theme JavaScript inlining support
 
 ### Stable Post attributes
 

--- a/blogmore.yaml.example
+++ b/blogmore.yaml.example
@@ -272,6 +272,11 @@ posts_per_feed: 20
 # Optional: Minify the CSS, writing it as styles.min.css (default: false)
 # minify_css: false
 
+# Optional: Bundle multiple CSS files into a single file (default: false)
+# When enabled, style.css, code.css, and local optimised FontAwesome CSS are
+# combined into a single bundle.css (or bundle.min.css).
+# bundle_css: false
+
 # Optional: Minify the JavaScript, writing it as theme.min.js (default: false)
 # If search is enabled, search.js is also minified as search.min.js.
 # minify_js: false

--- a/blogmore.yaml.example
+++ b/blogmore.yaml.example
@@ -281,6 +281,10 @@ posts_per_feed: 20
 # If search is enabled, search.js is also minified as search.min.js.
 # minify_js: false
 
+# Optional: Inline the theme JavaScript into the HTML (default: false)
+# When enabled, theme.js is embedded directly into the <head> of every page.
+# inline_theme_js: false
+
 # Optional: Minify all generated HTML output (default: false)
 # minify_html: false
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1118,6 +1118,19 @@ Minify the generated JavaScript and write it as `theme.min.js` instead of `theme
 minify_js: true
 ```
 
+#### `inline_theme_js`
+
+Inline the theme JavaScript into the HTML. When enabled, the theme detection and mobile menu JavaScript (`theme.js`) is embedded directly into the `<head>` of every generated HTML page.
+
+This eliminates one critical network request and ensures the theme is applied as early as possible, preventing any "flash of light mode" during page load.
+
+**Type:** Boolean  
+**Default:** `false`
+
+```yaml
+inline_theme_js: true
+```
+
 #### `minify_html`
 
 Minify all generated HTML output. When enabled, every `.html` file produced by BlogMore is minified before being saved. Unlike the CSS and JavaScript minification options, the output file name is not changed — only the content is minified.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1094,6 +1094,19 @@ Minify the generated CSS and write it as `styles.min.css` instead of `style.css`
 minify_css: true
 ```
 
+#### `bundle_css`
+
+Bundle multiple CSS files into a single file. When enabled, the main stylesheet (`style.css`), the code syntax highlighting CSS (`code.css`), and any local optimised FontAwesome CSS are combined into a single `bundle.css` (or `bundle.min.css` if `minify_css` is also enabled).
+
+This reduces the number of critical request chains and can significantly improve page load performance scores (like PageSpeed Insights) by reducing the number of network round trips.
+
+**Type:** Boolean  
+**Default:** `false`
+
+```yaml
+bundle_css: true
+```
+
 #### `minify_js`
 
 Minify the generated JavaScript and write it as `theme.min.js` instead of `theme.js`. If search is enabled, `search.js` is also minified and written as `search.min.js`. The original unminified files are not written when this option is enabled.

--- a/docs/template-api.md
+++ b/docs/template-api.md
@@ -49,6 +49,8 @@ below lists all variables that are available in every template.
 | `with_graph` | `bool` | `True` when the graph page is enabled. |
 | `graph_url` | `str` | URL to the graph page (respects `graph_path` and `clean_urls`). |
 | `graph_css_url` | `str` | URL to the graph-page stylesheet (with cache-bust query string). |
+| `inline_theme_js` | `bool` | `True` when theme JavaScript inlining is enabled. |
+| `theme_js_content` | `str \| None` | The content of `theme.js` to be inlined. |
 | `theme_js_url` | `str` | URL to `theme.js` (with cache-bust query string). |
 | `search_js_url` | `str` | URL to `search.js` (with cache-bust query string). |
 | `favicon_url` | `str \| None` | URL to the site favicon, if one exists. |

--- a/docs/template-api.md
+++ b/docs/template-api.md
@@ -32,6 +32,8 @@ below lists all variables that are available in every template.
 | `backlinks_title` | `str` | The heading text for the backlinks section (defaults to `"References & mentions"`). |
 | `with_advert` | `bool` | `True` when the "Generated with BlogMore" footer is shown. |
 | `default_author` | `str \| None` | Default author name from configuration. |
+| `bundle_css` | `bool` | `True` when CSS bundling is enabled. |
+| `bundle_css_url` | `str` | URL to the bundled stylesheet (with cache-bust query string). |
 | `styles_css_url` | `str` | URL to the compiled stylesheet (with cache-bust query string). |
 | `code_css_url` | `str` | URL to the generated code-highlighting stylesheet (with cache-bust query string). |
 | `search_css_url` | `str` | URL to the search-page stylesheet (with cache-bust query string). |
@@ -52,6 +54,7 @@ below lists all variables that are available in every template.
 | `favicon_url` | `str \| None` | URL to the site favicon, if one exists. |
 | `has_platform_icons` | `bool` | `True` when generated platform icons are present. |
 | `fontawesome_css_url` | `str \| None` | Font Awesome CSS URL, when social icons are used. |
+| `fontawesome_is_bundled` | `bool` | `True` when Font Awesome is included in the bundle. |
 | `extra_stylesheets` | `list[str]` | List of extra stylesheet URLs from configuration. |
 | `tag_dir` | `str` | URL prefix for tag pages (e.g. `/tags`). |
 | `category_dir` | `str` | URL prefix for category pages (e.g. `/categories`). |

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -16,6 +16,8 @@ BlogMore embeds several stylesheets in every generated site:
 - **`static/style.css`** — the main stylesheet, built around **CSS custom properties** (variables) so that colour schemes can be swapped by changing only those properties.
 - **`static/code.css`** — a generated stylesheet containing only the Pygments syntax-highlighting rules for the configured light and dark mode code styles.
 
+When `bundle_css` is enabled, these two files (along with any local optimised FontAwesome CSS) are combined into a single **`static/bundle.css`** (or `static/bundle.min.css`) to reduce the number of critical request chains and improve page load performance.
+
 The following page-specific stylesheets are included only in the pages that need them:
 
 - **`static/search.css`** — styles for the search page (included only in `search.html`).

--- a/examples/themes/modern-compact/templates/base.html
+++ b/examples/themes/modern-compact/templates/base.html
@@ -35,6 +35,19 @@
     <meta name="msapplication-config" content="/icons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     {% endif %}
+    {% if bundle_css %}
+    {% if fontawesome_css_url %}
+    <link rel="preload" href="{{ fontawesome_woff2_url }}" as="font" type="font/woff2" crossorigin="anonymous">
+    {% if not fontawesome_is_bundled %}
+    <link rel="stylesheet" href="{{ fontawesome_css_url }}">
+    {% endif %}
+    {% endif %}
+    <!-- Custom Google Fonts for the modern-compact theme -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ bundle_css_url }}">
+    {% else %}
     {% if fontawesome_css_url %}
     <link rel="preload" href="{{ fontawesome_woff2_url }}" as="font" type="font/woff2" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ fontawesome_css_url }}">
@@ -45,6 +58,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ styles_css_url }}">
     <link rel="stylesheet" href="{{ code_css_url }}">
+    {% endif %}
     {% if extra_stylesheets %}
     {% for stylesheet in extra_stylesheets %}
     <link rel="stylesheet" href="{{ stylesheet }}">

--- a/examples/themes/modern-compact/templates/base.html
+++ b/examples/themes/modern-compact/templates/base.html
@@ -74,7 +74,11 @@
     {% endif %}
     {% endblock %}
     {% block meta_tags %}{% endblock %}
+    {% if inline_theme_js and theme_js_content %}
+    <script>{{ theme_js_content | safe }}</script>
+    {% else %}
     <script src="{{ theme_js_url }}"></script>
+    {% endif %}
     <script src="{{ codeblocks_js_url }}" defer></script>
     {% if prev_page_url %}<link rel="prev" href="{{ prev_page_url }}">{% endif %}
     {% if next_page_url %}<link rel="next" href="{{ next_page_url }}">{% endif %}

--- a/src/blogmore/generator/assets.py
+++ b/src/blogmore/generator/assets.py
@@ -353,6 +353,17 @@ class AssetManager:
         output_path.write_text(minified, encoding="utf-8")
         print(f"Generated minified JS as {js_min}")
 
+    def get_theme_js_content(self) -> str | None:
+        """Return the content of the theme JavaScript, optionally minified.
+
+        Returns:
+            The JS content string, or ``None`` if not found.
+        """
+        source = self._get_asset_source(THEME_JS_FILENAME)
+        if source and self.site_config.minify_js:
+            return rjsmin.jsmin(source)
+        return source
+
     def copy_static_assets(self) -> None:
         """Copy static assets (CSS, JS, images) to output directory.
 

--- a/src/blogmore/generator/assets.py
+++ b/src/blogmore/generator/assets.py
@@ -19,6 +19,7 @@ from blogmore.fontawesome import (
     FontAwesomeOptimizer,
 )
 from blogmore.generator.constants import (
+    BUNDLE_CSS_FILENAME,
     CODE_CSS_FILENAME,
     CODEBLOCKS_JS_FILENAME,
     CSS_FILENAME,
@@ -46,6 +47,7 @@ class AssetManager:
         """
         self.site_config = site_config
         self.fontawesome_css_url: str = FONTAWESOME_CDN_CSS_URL
+        self._fontawesome_css_content: str | None = None
         self.extras_html_paths: frozenset[str] = frozenset()
 
     @property
@@ -57,6 +59,15 @@ class AssetManager:
         """
         assert self.site_config.content_dir is not None
         return self.site_config.content_dir
+
+    @property
+    def fontawesome_is_bundled(self) -> bool:
+        """Return whether FontAwesome CSS is included in the bundle.
+
+        Returns:
+            True if FontAwesome was optimized and is ready for bundling.
+        """
+        return self._fontawesome_css_content is not None
 
     def detect_favicon(self) -> str | None:
         """Detect if a favicon file exists in the icons or extras directory.
@@ -180,7 +191,8 @@ class AssetManager:
             else FONTAWESOME_LOCAL_CSS_PATH
         )
         with timed_step("Optimizing FontAwesome CSS..."):
-            return optimizer.build_css(metadata)
+            self._fontawesome_css_content = optimizer.build_css(metadata)
+            return self._fontawesome_css_content
 
     def _get_asset_source(self, filename: str) -> str | None:
         """Read the text content of a static asset, preferring custom over bundled.
@@ -277,6 +289,46 @@ class AssetManager:
             output_path = output_static / CODE_CSS_FILENAME
             output_path.write_text(css_content, encoding="utf-8")
             print(f"Generated code CSS as {CODE_CSS_FILENAME}")
+
+    def _write_bundled_css(self, output_static: Path) -> None:
+        """Bundle and optionally minify critical CSS files.
+
+        Combines FontAwesome (if local), main stylesheet, and code syntax
+        highlighting into a single bundled CSS file.
+
+        Args:
+            output_static: Path to the output static directory.
+        """
+        bundle_parts = []
+
+        # 1. FontAwesome (if local and optimised)
+        if self._fontawesome_css_content:
+            bundle_parts.append(self._fontawesome_css_content)
+
+        # 2. Main stylesheet
+        style_source = self._get_asset_source(CSS_FILENAME)
+        if style_source:
+            bundle_parts.append(style_source)
+
+        # 3. Code syntax highlighting
+        code_source = build_code_css(
+            self.site_config.light_mode_code_style,
+            self.site_config.dark_mode_code_style,
+        )
+        bundle_parts.append(code_source)
+
+        combined = "\n".join(bundle_parts)
+
+        if self.site_config.minify_css:
+            minified = rcssmin.cssmin(combined)
+            bundle_min = minified_filename(BUNDLE_CSS_FILENAME)
+            output_path = output_static / bundle_min
+            output_path.write_text(minified, encoding="utf-8")
+            print(f"Generated minified bundled CSS as {bundle_min}")
+        else:
+            output_path = output_static / BUNDLE_CSS_FILENAME
+            output_path.write_text(combined, encoding="utf-8")
+            print(f"Generated bundled CSS as {BUNDLE_CSS_FILENAME}")
 
     def _write_minified_js(self, output_static: Path, js_filename: str) -> None:
         """Read a source JavaScript file, minify it, and write it with the minified name.
@@ -418,6 +470,10 @@ class AssetManager:
         # Minify CSS if requested
         if self.site_config.minify_css:
             self._write_minified_css(output_static)
+
+        # Bundle CSS if requested
+        if self.site_config.bundle_css:
+            self._write_bundled_css(output_static)
 
         # Always generate code.css (or code.min.css) from configured Pygments styles.
         self._write_code_css(output_static)

--- a/src/blogmore/generator/assets.py
+++ b/src/blogmore/generator/assets.py
@@ -361,7 +361,7 @@ class AssetManager:
         """
         source = self._get_asset_source(THEME_JS_FILENAME)
         if source and self.site_config.minify_js:
-            return rjsmin.jsmin(source)
+            return str(rjsmin.jsmin(source))
         return source
 
     def copy_static_assets(self) -> None:

--- a/src/blogmore/generator/constants.py
+++ b/src/blogmore/generator/constants.py
@@ -5,6 +5,7 @@ TAG_DIR = "tag"
 CATEGORY_DIR = "category"
 
 CSS_FILENAME = "style.css"
+BUNDLE_CSS_FILENAME = "bundle.css"
 SEARCH_CSS_FILENAME = "search.css"
 STATS_CSS_FILENAME = "stats.css"
 ARCHIVE_CSS_FILENAME = "archive.css"

--- a/src/blogmore/generator/context.py
+++ b/src/blogmore/generator/context.py
@@ -9,6 +9,7 @@ from blogmore.clean_url import make_url_clean
 from blogmore.fontawesome import FONTAWESOME_CDN_BRANDS_WOFF2_URL
 from blogmore.generator.constants import (
     ARCHIVE_CSS_FILENAME,
+    BUNDLE_CSS_FILENAME,
     CALENDAR_CSS_FILENAME,
     CATEGORY_DIR,
     CODE_CSS_FILENAME,
@@ -40,6 +41,7 @@ class ContextBuilder:
         favicon_url: str | None = None,
         has_platform_icons: bool = False,
         fontawesome_css_url: str = "",
+        fontawesome_is_bundled: bool = False,
     ) -> None:
         """Initialize the context builder.
 
@@ -49,12 +51,14 @@ class ContextBuilder:
             favicon_url: URL for the site favicon.
             has_platform_icons: Whether generated platform icons exist.
             fontawesome_css_url: URL for the FontAwesome stylesheet.
+            fontawesome_is_bundled: Whether FontAwesome is included in the bundle.
         """
         self.site_config = site_config
         self.cache_bust_token = cache_bust_token
         self.favicon_url = favicon_url
         self.has_platform_icons = has_platform_icons
         self.fontawesome_css_url = fontawesome_css_url
+        self.fontawesome_is_bundled = fontawesome_is_bundled
 
     def with_cache_bust(self, url: str) -> str:
         """Return a URL with a cache-busting query parameter appended.
@@ -220,6 +224,11 @@ class ContextBuilder:
             "with_advert": self.site_config.with_advert,
             "default_author": self.site_config.default_author,
             "extra_head_tags": self.site_config.head,
+            "bundle_css": self.site_config.bundle_css,
+            "bundle_css_url": self.get_asset_url(
+                BUNDLE_CSS_FILENAME, self.site_config.minify_css
+            ),
+            "fontawesome_is_bundled": self.fontawesome_is_bundled,
             "fontawesome_css_url": self.with_cache_bust(self.fontawesome_css_url),
             "fontawesome_woff2_url": FONTAWESOME_CDN_BRANDS_WOFF2_URL,
             "styles_css_url": self.get_asset_url(

--- a/src/blogmore/generator/context.py
+++ b/src/blogmore/generator/context.py
@@ -42,6 +42,7 @@ class ContextBuilder:
         has_platform_icons: bool = False,
         fontawesome_css_url: str = "",
         fontawesome_is_bundled: bool = False,
+        theme_js_content: str | None = None,
     ) -> None:
         """Initialize the context builder.
 
@@ -52,6 +53,7 @@ class ContextBuilder:
             has_platform_icons: Whether generated platform icons exist.
             fontawesome_css_url: URL for the FontAwesome stylesheet.
             fontawesome_is_bundled: Whether FontAwesome is included in the bundle.
+            theme_js_content: The content of theme.js for inlining.
         """
         self.site_config = site_config
         self.cache_bust_token = cache_bust_token
@@ -59,6 +61,7 @@ class ContextBuilder:
         self.has_platform_icons = has_platform_icons
         self.fontawesome_css_url = fontawesome_css_url
         self.fontawesome_is_bundled = fontawesome_is_bundled
+        self.theme_js_content = theme_js_content
 
     def with_cache_bust(self, url: str) -> str:
         """Return a URL with a cache-busting query parameter appended.
@@ -228,6 +231,8 @@ class ContextBuilder:
             "bundle_css_url": self.get_asset_url(
                 BUNDLE_CSS_FILENAME, self.site_config.minify_css
             ),
+            "inline_theme_js": self.site_config.inline_theme_js,
+            "theme_js_content": self.theme_js_content,
             "fontawesome_is_bundled": self.fontawesome_is_bundled,
             "fontawesome_css_url": self.with_cache_bust(self.fontawesome_css_url),
             "fontawesome_woff2_url": FONTAWESOME_CDN_BRANDS_WOFF2_URL,

--- a/src/blogmore/generator/site.py
+++ b/src/blogmore/generator/site.py
@@ -164,6 +164,7 @@ class SiteGenerator:
         # Update context builder with discovered asset state.
         context_builder.favicon_url = asset_manager.detect_favicon()
         context_builder.has_platform_icons = asset_manager.detect_generated_icons()
+        context_builder.fontawesome_is_bundled = asset_manager.fontawesome_is_bundled
         context_builder.fontawesome_css_url = asset_manager.fontawesome_css_url
 
         # Resolve paths

--- a/src/blogmore/generator/site.py
+++ b/src/blogmore/generator/site.py
@@ -166,6 +166,7 @@ class SiteGenerator:
         context_builder.has_platform_icons = asset_manager.detect_generated_icons()
         context_builder.fontawesome_is_bundled = asset_manager.fontawesome_is_bundled
         context_builder.fontawesome_css_url = asset_manager.fontawesome_css_url
+        context_builder.theme_js_content = asset_manager.get_theme_js_content()
 
         # Resolve paths
         page_output_paths = resolve_page_output_paths(self.site_config, pages)

--- a/src/blogmore/site_config.py
+++ b/src/blogmore/site_config.py
@@ -139,6 +139,16 @@ class SiteConfig:
     minify_css: bool = False
     """Whether to minify the CSS, writing it as `styles.min.css`."""
 
+    bundle_css: bool = False
+    """Whether to bundle multiple CSS files into a single file.
+
+    When enabled, the main stylesheet (``style.css``), the code syntax
+    highlighting CSS (``code.css``), and any local optimised FontAwesome
+    CSS are combined into a single ``bundle.css`` (or ``bundle.min.css``).
+    This reduces the number of network requests and can improve page load
+    performance.  Off by default.
+    """
+
     minify_js: bool = False
     """Whether to minify the JavaScript output files."""
 

--- a/src/blogmore/site_config.py
+++ b/src/blogmore/site_config.py
@@ -152,6 +152,16 @@ class SiteConfig:
     minify_js: bool = False
     """Whether to minify the JavaScript output files."""
 
+    inline_theme_js: bool = False
+    """Whether to inline the theme JavaScript into the HTML.
+
+    When enabled, the theme detection and mobile menu JavaScript
+    (``theme.js``) is embedded directly into the ``<head>`` of every
+    generated HTML page.  This eliminates one critical network request
+    and ensures the theme is applied as early as possible.  Off by
+    default.
+    """
+
     minify_html: bool = False
     """Whether to minify all generated HTML output.
 

--- a/src/blogmore/templates/base.html
+++ b/src/blogmore/templates/base.html
@@ -27,12 +27,22 @@
     <meta name="msapplication-config" content="/icons/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     {% endif %}
+    {% if bundle_css %}
+    {% if fontawesome_css_url %}
+    <link rel="preload" href="{{ fontawesome_woff2_url }}" as="font" type="font/woff2" crossorigin="anonymous">
+    {% if not fontawesome_is_bundled %}
+    <link rel="stylesheet" href="{{ fontawesome_css_url }}">
+    {% endif %}
+    {% endif %}
+    <link rel="stylesheet" href="{{ bundle_css_url }}">
+    {% else %}
     {% if fontawesome_css_url %}
     <link rel="preload" href="{{ fontawesome_woff2_url }}" as="font" type="font/woff2" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ fontawesome_css_url }}">
     {% endif %}
     <link rel="stylesheet" href="{{ styles_css_url }}">
     <link rel="stylesheet" href="{{ code_css_url }}">
+    {% endif %}
     {% if extra_stylesheets %}
     {% for stylesheet in extra_stylesheets %}
     <link rel="stylesheet" href="{{ stylesheet }}">

--- a/src/blogmore/templates/base.html
+++ b/src/blogmore/templates/base.html
@@ -58,7 +58,11 @@
     {% endif %}
     {% endblock %}
     {% block meta_tags %}{% endblock %}
+    {% if inline_theme_js and theme_js_content %}
+    <script>{{ theme_js_content | safe }}</script>
+    {% else %}
     <script src="{{ theme_js_url }}"></script>
+    {% endif %}
     <script src="{{ codeblocks_js_url }}" defer></script>
     {% if prev_page_url %}<link rel="prev" href="{{ prev_page_url }}">{% endif %}
     {% if next_page_url %}<link rel="next" href="{{ next_page_url }}">{% endif %}

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1959,6 +1959,66 @@ class TestBundleCss:
         assert ".highlight" in bundle_content
 
 
+class TestInlineThemeJs:
+    """Test the inline_theme_js feature."""
+
+    def test_inline_theme_js_false_by_default(
+        self, posts_dir: Path, temp_output_dir: Path
+    ) -> None:
+        """Test that theme JS is not inlined by default."""
+        generator = SiteGenerator(
+            site_config=SiteConfig(content_dir=posts_dir, output_dir=temp_output_dir)
+        )
+
+        generator.generate()
+
+        index_content = (temp_output_dir / "index.html").read_text()
+        assert "/static/theme.js" in index_content
+        # Check that it's NOT inlined (no script tag with content)
+        # theme.js starts with '/**'
+        assert "<script>/**" not in index_content
+
+    def test_inline_theme_js_true_inlines_content(
+        self, posts_dir: Path, temp_output_dir: Path
+    ) -> None:
+        """Test that theme JS is inlined when enabled."""
+        generator = SiteGenerator(
+            site_config=SiteConfig(
+                content_dir=posts_dir, output_dir=temp_output_dir, inline_theme_js=True
+            )
+        )
+
+        generator.generate()
+
+        index_content = (temp_output_dir / "index.html").read_text()
+        assert "/static/theme.js" not in index_content
+        # Check that it's inlined (theme.js content should be present)
+        assert "Theme switching functionality for BlogMore" in index_content
+
+    def test_inline_theme_js_with_minify_js(
+        self, posts_dir: Path, temp_output_dir: Path
+    ) -> None:
+        """Test that inlined theme JS is minified when minify_js is true."""
+        generator = SiteGenerator(
+            site_config=SiteConfig(
+                content_dir=posts_dir,
+                output_dir=temp_output_dir,
+                inline_theme_js=True,
+                minify_js=True,
+            )
+        )
+
+        generator.generate()
+
+        index_content = (temp_output_dir / "index.html").read_text()
+        assert "/static/theme.js" not in index_content
+        assert "/static/theme.min.js" not in index_content
+        # Check for minified content (no comments)
+        assert "Theme switching functionality for BlogMore" not in index_content
+        # But some known function/variable should be there
+        assert "THEME_COOKIE_NAME" in index_content
+
+
 class TestMinifyCss:
     """Test the minify_css feature."""
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1870,6 +1870,95 @@ class TestSiteGenerator:
         assert '<meta name="twitter:image"' not in content
 
 
+class TestBundleCss:
+    """Test the bundle_css feature."""
+
+    def test_bundle_css_false_by_default(
+        self, posts_dir: Path, temp_output_dir: Path
+    ) -> None:
+        """Test that CSS is not bundled by default."""
+        generator = SiteGenerator(
+            site_config=SiteConfig(content_dir=posts_dir, output_dir=temp_output_dir)
+        )
+
+        generator.generate()
+
+        assert (temp_output_dir / "static" / "style.css").exists()
+        assert (temp_output_dir / "static" / "code.css").exists()
+        assert not (temp_output_dir / "static" / "bundle.css").exists()
+
+    def test_bundle_css_generates_bundle_css(
+        self, posts_dir: Path, temp_output_dir: Path
+    ) -> None:
+        """Test that bundle_css generates bundle.css."""
+        generator = SiteGenerator(
+            site_config=SiteConfig(
+                content_dir=posts_dir, output_dir=temp_output_dir, bundle_css=True
+            )
+        )
+
+        generator.generate()
+
+        assert (temp_output_dir / "static" / "bundle.css").exists()
+
+    def test_bundle_css_url_in_html(
+        self, posts_dir: Path, temp_output_dir: Path
+    ) -> None:
+        """Test that pages reference bundle.css when bundle_css is enabled."""
+        generator = SiteGenerator(
+            site_config=SiteConfig(
+                content_dir=posts_dir, output_dir=temp_output_dir, bundle_css=True
+            )
+        )
+
+        generator.generate()
+
+        content = (temp_output_dir / "index.html").read_text()
+        assert "/static/bundle.css" in content
+        assert "/static/style.css" not in content
+        assert "/static/code.css" not in content
+
+    def test_bundle_css_with_minify_generates_min_bundle(
+        self, posts_dir: Path, temp_output_dir: Path
+    ) -> None:
+        """Test that bundle_css with minify_css generates bundle.min.css."""
+        generator = SiteGenerator(
+            site_config=SiteConfig(
+                content_dir=posts_dir,
+                output_dir=temp_output_dir,
+                bundle_css=True,
+                minify_css=True,
+            )
+        )
+
+        generator.generate()
+
+        assert (temp_output_dir / "static" / "bundle.min.css").exists()
+        assert not (temp_output_dir / "static" / "bundle.css").exists()
+
+        content = (temp_output_dir / "index.html").read_text()
+        assert "/static/bundle.min.css" in content
+
+    def test_bundle_css_contains_component_styles(
+        self, posts_dir: Path, temp_output_dir: Path
+    ) -> None:
+        """Test that bundle.css contains content from style.css and code.css."""
+        generator = SiteGenerator(
+            site_config=SiteConfig(
+                content_dir=posts_dir, output_dir=temp_output_dir, bundle_css=True
+            )
+        )
+
+        generator.generate()
+
+        bundle_content = (temp_output_dir / "static" / "bundle.css").read_text()
+
+        # Check for something likely to be in style.css
+        assert "body" in bundle_content
+        # Check for something likely to be in code.css (Pygments classes)
+        assert ".highlight" in bundle_content
+
+
 class TestMinifyCss:
     """Test the minify_css feature."""
 


### PR DESCRIPTION
## Optional CSS bundling

Until now BlogMore has created `style.css`, `code.css` and `fontawesome.css`. Now, if `bundle_css: true` is set in the configuration file, all three files are bundled into `bundle.css` (or `bundle.min.css` if CSS minificiation is enabled) so that the browser only need make one request whereas before it needed to make three.

## Optional theme-handling inlining

Because `theme.js` isn't that big, and loading it costs some time (when it isn't in the client cache), there is now an option to inline this in every page (`inline_theme_js: true`). This is the more dubious of the changes here, in that once `theme.js` is in the reader's cache it's there until there's a new build the site, whereas every fresh page of a site they view they'll get a new copy of this downloaded as part of the page's HTML (when done inline).

Adding it because why the heck not, but I doubt I'll run with this set to `true`.