### PR TITLE
Rename "References & mentions" to "References & Mentions"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # BlogMore ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Renamed the default backlinks section title from "References & mentions"
+  to "References & Mentions".
+  ([#544](https://github.com/davep/blogmore/pull/544))
+
 ## v2.30.0
 
 **Released: 2026-05-26**

--- a/blogmore.yaml.example
+++ b/blogmore.yaml.example
@@ -161,19 +161,19 @@ posts_per_feed: 20
 # Must be a positive integer. Configuration file only.
 # read_time_wpm: 200
 
-# Optional: Show "References & mentions" section on individual post pages (default: false)
+# Optional: Show "References & Mentions" section on individual post pages (default: false)
 # When enabled, BlogMore scans all post content for internal links and shows a
-# "References & mentions" section on each linked-to post page, listing which
+# "References & Mentions" section on each linked-to post page, listing which
 # posts link to it along with a short plain-text context snippet.
 # Only links in posts are considered; links in static pages are excluded.
 # Configuration file only.
 # with_backlinks: false
 
-# Optional: Title for the backlinks section heading (default: "References & mentions")
-# Overrides the heading displayed in the "References & mentions" section on post
+# Optional: Title for the backlinks section heading (default: "References & Mentions")
+# Overrides the heading displayed in the "References & Mentions" section on post
 # pages when with_backlinks is enabled.
 # Configuration file only.
-# backlinks_title: "References & mentions"
+# backlinks_title: "References & Mentions"
 
 # Optional: Enable comment invitation section on individual post pages (default: false)
 # When true and invite_comments_to is also set, every post will show a subtle

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -533,7 +533,7 @@ read_time_wpm: 250
 
 #### `with_backlinks`
 
-Enable the "References &amp; mentions" section on individual post pages.  When enabled, BlogMore scans the Markdown content of every post for internal links and builds a map of which posts link to which other posts.  Any post that is linked to by at least one other post will have a "References &amp; mentions" section displayed after the bottom previous/next navigation, listing the posts that link to it together with a short plain-text context snippet showing where the link appears in the source post.
+Enable the "References &amp; Mentions" section on individual post pages.  When enabled, BlogMore scans the Markdown content of every post for internal links and builds a map of which posts link to which other posts.  Any post that is linked to by at least one other post will have a "References &amp; Mentions" section displayed after the bottom previous/next navigation, listing the posts that link to it together with a short plain-text context snippet showing where the link appears in the source post.
 
 Only links found in the Markdown of *posts* are considered — links found in static *pages* are excluded.  Self-links (a post linking to itself) and the title links BlogMore adds in the references section itself are also excluded.
 
@@ -550,20 +550,20 @@ with_backlinks: true
 
 #### `backlinks_title`
 
-Override the heading displayed at the top of the "References &amp; mentions" section on individual post pages.  Only meaningful when [`with_backlinks`](#with_backlinks) is `true`.
+Override the heading displayed at the top of the "References &amp; Mentions" section on individual post pages.  Only meaningful when [`with_backlinks`](#with_backlinks) is `true`.
 
-This is a **configuration file only** option — it cannot be set on the command line.  Defaults to `"References & mentions"`.
+This is a **configuration file only** option — it cannot be set on the command line.  Defaults to `"References & Mentions"`.
 
 **Type:** String  
-**Default:** `"References & mentions"`
+**Default:** `"References & Mentions"`
 
 ```yaml
-backlinks_title: "References & mentions"
+backlinks_title: "References & Mentions"
 ```
 
 #### `invite_comments`
 
-Enable a comment invitation section on individual post pages.  When `true` and [`invite_comments_to`](#invite_comments_to) is also configured, every post will display a subtle invitation section towards the bottom of the page, after the next/previous navigation buttons and before any "References &amp; mentions" section.  The section contains a `mailto:` link so readers can email their comments or questions about the post.
+Enable a comment invitation section on individual post pages.  When `true` and [`invite_comments_to`](#invite_comments_to) is also configured, every post will display a subtle invitation section towards the bottom of the page, after the next/previous navigation buttons and before any "References &amp; Mentions" section.  The section contains a `mailto:` link so readers can email their comments or questions about the post.
 
 The invitation section is a Jinja2 template (`_comment_invite.html`) that can be overridden in a custom templates directory.
 

--- a/docs/template-api.md
+++ b/docs/template-api.md
@@ -29,7 +29,7 @@ below lists all variables that are available in every template.
 | `categories_url` | `str` | URL to the categories overview page (respects `categories_path` and `clean_urls`). |
 | `with_read_time` | `bool` | `True` when reading time display is enabled. |
 | `with_backlinks` | `bool` | `True` when the backlinks feature is enabled. |
-| `backlinks_title` | `str` | The heading text for the backlinks section (defaults to `"References & mentions"`). |
+| `backlinks_title` | `str` | The heading text for the backlinks section (defaults to `"References & Mentions"`). |
 | `with_related` | `bool` | `True` when the related posts feature is enabled. |
 | `related_title` | `str` | The heading text for the related posts section (defaults to `"Related Posts"`). |
 | `with_advert` | `bool` | `True` when the "Generated with BlogMore" footer is shown. |
@@ -354,7 +354,7 @@ widget.  It is called like this:
 
 | Block | Description |
 |---|---|
-| `backlinks` | The "References &amp; mentions" section shown after the bottom post-navigation on individual post pages when `with_backlinks` is enabled and there are inbound links.  Override this block in a custom `post.html` to change the layout or styling of the section. |
+| `backlinks` | The "References &amp; Mentions" section shown after the bottom post-navigation on individual post pages when `with_backlinks` is enabled and there are inbound links.  Override this block in a custom `post.html` to change the layout or styling of the section. |
 | `comment_invite` | The comment invitation section shown after the bottom post-navigation (and before the `backlinks` block) when `invite_comments` is enabled.  By default this block includes `_comment_invite.html`.  Override `_comment_invite.html` in your custom templates directory to change the wording or layout, or override this block entirely in a custom `post.html`. |
 
 ## CSS classes used by templates
@@ -384,7 +384,7 @@ The following CSS classes are part of the stable template/CSS contract:
 | `.category-link` | `a` | Category badge link. |
 | `.theme-toggle` | `button` | Dark/light mode toggle button. |
 | `.highlight` | `div` | Syntax-highlighted code block. |
-| `.backlinks` | `section` | "References &amp; mentions" container on a post page (only when `with_backlinks` is enabled and the post has inbound links). |
+| `.backlinks` | `section` | "References &amp; Mentions" container on a post page (only when `with_backlinks` is enabled and the post has inbound links). |
 | `.backlinks-heading` | `h2` | Heading of the backlinks section. |
 | `.backlinks-list` | `ul` | Ordered list of back-linking posts. |
 | `.backlink-item` | `li` | A single back-link entry (one per referencing post). |

--- a/src/blogmore/backlinks.py
+++ b/src/blogmore/backlinks.py
@@ -1,7 +1,7 @@
 """Back-linking system for BlogMore.
 
 Calculates which posts link to other posts, providing data for a
-"References & mentions" section displayed on individual post pages.
+"References & Mentions" section displayed on individual post pages.
 
 This module is only consulted when `with_backlinks` is enabled in the
 site configuration.  When the feature is disabled none of these functions

--- a/src/blogmore/site_config.py
+++ b/src/blogmore/site_config.py
@@ -175,11 +175,11 @@ class SiteConfig:
     """
 
     with_backlinks: bool = False
-    """Whether to show a "References & mentions" section on individual post pages.
+    """Whether to show a "References & Mentions" section on individual post pages.
 
     When enabled the generator scans all post content for internal links and
     builds a map of which posts link to which other posts.  On each post page
-    that is referenced by at least one other post, a "References & mentions"
+    that is referenced by at least one other post, a "References & Mentions"
     section is appended below the bottom post-navigation links, listing the
     posts that link here together with a short plain-text snippet showing the
     surrounding context of each link.
@@ -191,15 +191,15 @@ class SiteConfig:
     command line.  Off by default.
     """
 
-    backlinks_title: str = "References & mentions"
+    backlinks_title: str = "References & Mentions"
     """Title displayed as the heading of the backlinks section on post pages.
 
-    Overrides the default "References & mentions" heading rendered inside the
+    Overrides the default "References & Mentions" heading rendered inside the
     ``backlinks`` template block on individual post pages.  Only meaningful
     when ``with_backlinks`` is ``True``.
 
     This is a **configuration file only** option — it cannot be set on the
-    command line.  Defaults to ``"References & mentions"``.
+    command line.  Defaults to ``"References & Mentions"``.
     """
 
     socials_title: str = "Social"
@@ -601,7 +601,7 @@ class SiteConfig:
     When ``True`` and ``invite_comments_to`` is also configured, every
     post will display a comment invitation section towards the bottom of the
     page, after the next/previous navigation buttons and before any
-    "References & mentions" section.
+    "References & Mentions" section.
 
     The per-post ``invite_comments`` front-matter key overrides this setting
     for individual posts.

--- a/src/blogmore/templates/static/style.css
+++ b/src/blogmore/templates/static/style.css
@@ -869,10 +869,10 @@ time a:visited {
 }
 
 /* =============================================================================
-   BACKLINKS (References & mentions)
+   BACKLINKS (References & Mentions)
    ============================================================================= */
 
-/* Container for the "References & mentions" section on individual post pages. */
+/* Container for the "References & Mentions" section on individual post pages. */
 .backlinks {
     margin-top: 2rem;
     padding-top: 1.5rem;

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -509,7 +509,7 @@ class TestBacklinksTitle:
     def test_default_backlinks_title(
         self, tmp_path: Path, temp_output_dir: Path
     ) -> None:
-        """Test that the default backlinks title is 'References & mentions'."""
+        """Test that the default backlinks title is 'References & Mentions'."""
         from blogmore.generator import SiteGenerator
 
         content_dir = tmp_path / "content"
@@ -529,7 +529,7 @@ class TestBacklinksTitle:
         target_html = (
             temp_output_dir / "2024" / "01" / "10" / "target-post.html"
         ).read_text()
-        assert "References &amp; mentions" in target_html
+        assert "References &amp; Mentions" in target_html
 
     def test_custom_backlinks_title(
         self, tmp_path: Path, temp_output_dir: Path
@@ -556,12 +556,12 @@ class TestBacklinksTitle:
             temp_output_dir / "2024" / "01" / "10" / "target-post.html"
         ).read_text()
         assert "Cited by" in target_html
-        assert "References &amp; mentions" not in target_html
+        assert "References &amp; Mentions" not in target_html
 
     def test_backlinks_title_default_value(self, tmp_path: Path) -> None:
-        """Test that SiteConfig defaults backlinks_title to 'References & mentions'."""
+        """Test that SiteConfig defaults backlinks_title to 'References & Mentions'."""
         config = SiteConfig(output_dir=tmp_path)
-        assert config.backlinks_title == "References & mentions"
+        assert config.backlinks_title == "References & Mentions"
 
 
 class TestRelatedTitle:


### PR DESCRIPTION
Better matches the title case used in other parts of the system.