### PR TITLE
Extend the graph to show either linkage or relatedness

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@
 - Renamed the default backlinks section title from "References & mentions"
   to "References & Mentions".
   ([#544](https://github.com/davep/blogmore/pull/544))
+- Added an alternative relatedness graph view to the graph page when the
+  related posts feature (`with_related`) is enabled.
+  ([#546](https://github.com/davep/blogmore/pull/546))
 
 ## v2.30.0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -451,6 +451,8 @@ The graph visualises three types of node:
 
 Edges connect each post to the tags and categories it carries, and to any other posts it links to internally via Markdown links.  Clicking a post node navigates to that post; clicking a tag or category node navigates to the corresponding archive.
 
+If the related posts feature ([`with_related`](#with_related)) is also enabled, the graph page includes a toggle switch to transition between this standard view and an alternative **Related** view. The Related view displays only post nodes, connecting them based on content similarity as calculated by the TF-IDF matching engine.
+
 The graph respects the active light/dark theme and is fully responsive.  A **Graph** link is automatically added to the navigation bar between **Calendar** and **RSS**.
 
 Off by default.

--- a/docs/template-api.md
+++ b/docs/template-api.md
@@ -128,6 +128,7 @@ or `/tag/python/` when `clean_urls` is enabled.
 | `search.html` | `pages`, `canonical_url` |
 | `stats.html` | `stats` (`BlogStats`), `pages`, `canonical_url` |
 | `calendar.html` | `calendar_years` (list of `CalendarYear`), `pages`, `canonical_url` |
+| `graph.html` | `graph_data_json` (`str`), `related_graph_data_json` (`str | None`), `pages`, `canonical_url` |
 
 ## Post object
 

--- a/src/blogmore/generator/features.py
+++ b/src/blogmore/generator/features.py
@@ -12,7 +12,7 @@ from blogmore.generator.constants import CATEGORY_DIR, TAG_DIR
 from blogmore.generator.grouping import group_posts_by_category
 from blogmore.generator.html import write_html
 from blogmore.generator.paths import canonical_url_for_path
-from blogmore.graph import GraphData, build_graph_data
+from blogmore.graph import GraphData, build_graph_data, build_related_graph_data
 from blogmore.parser import Page, Post, post_sort_key
 from blogmore.search import write_search_index
 from blogmore.sitemap import write_sitemap
@@ -220,8 +220,15 @@ class FeatureGenerator:
             category_dir=CATEGORY_DIR,
             site_url=self.site_config.site_url,
         )
+        related_graph_data_json: str | None = None
+        if self.site_config.with_related:
+            related_graph_data = build_related_graph_data(posts)
+            related_graph_data_json = related_graph_data.to_json()
+
         html = self.renderer.render_graph_page(
-            graph_data_json=graph_data.to_json(), **context
+            graph_data_json=graph_data.to_json(),
+            related_graph_data_json=related_graph_data_json,
+            **context,
         )
         write_html(output_path, html, self.site_config.minify_html)
 

--- a/src/blogmore/graph.py
+++ b/src/blogmore/graph.py
@@ -206,4 +206,59 @@ def build_graph_data(
     return graph
 
 
+def build_related_graph_data(posts: list[Post]) -> GraphData:
+    """Build force-directed graph data based purely on post relatedness.
+
+    Creates one node for every post. Adds edges between posts that are
+    related to each other (i.e., if one is in the other's related_posts list).
+
+    Args:
+        posts: All published posts for the site.
+
+    Returns:
+        A [`blogmore.graph.GraphData`][blogmore.graph.GraphData] instance populated with post nodes and
+        relatedness links.
+    """
+    graph = GraphData()
+
+    # --- Post nodes -----------------------------------------------------------
+    for post in posts:
+        raw_cover: str | None = (
+            str(post.metadata["cover"])
+            if post.metadata and post.metadata.get("cover")
+            else None
+        )
+        if raw_cover is None:
+            cover: str | None = None
+        elif raw_cover.startswith(("http://", "https://", "/")):
+            cover = raw_cover
+        else:
+            cover = f"/{raw_cover}"
+        graph.nodes.append(
+            {
+                "id": post.url,
+                "label": post.title,
+                "type": "post",
+                "url": post.url,
+                "date": post.date.strftime("%Y-%m-%d") if post.date else None,
+                "description": post.description,
+                "cover": cover,
+            }
+        )
+
+    # --- Post->post edges from related posts ----------------------------------
+    link_pairs: set[tuple[str, str]] = set()
+    for post in posts:
+        related_posts = getattr(post, "related_posts", [])
+        for rel in related_posts:
+            if rel.url == post.url:
+                continue
+            pair = (post.url, rel.url) if post.url < rel.url else (rel.url, post.url)
+            if pair not in link_pairs:
+                link_pairs.add(pair)
+                graph.links.append({"source": post.url, "target": rel.url})
+
+    return graph
+
+
 ### graph.py ends here

--- a/src/blogmore/templates/graph.html
+++ b/src/blogmore/templates/graph.html
@@ -16,26 +16,35 @@
     <h1>Graph</h1>
 
     <div class="graph-toolbar">
-        <div class="graph-legend" role="group" aria-label="Graph legend">
+        <div class="graph-legend" id="graph-legend" role="group" aria-label="Graph legend">
             <span class="graph-legend-item">
                 <span class="graph-legend-shape graph-legend-shape--post" aria-hidden="true"></span>
                 Posts
             </span>
-            <span class="graph-legend-item">
+            <span class="graph-legend-item" id="graph-legend-tags">
                 <span class="graph-legend-shape graph-legend-shape--tag" aria-hidden="true"></span>
                 Tags
             </span>
-            <span class="graph-legend-item">
+            <span class="graph-legend-item" id="graph-legend-categories">
                 <span class="graph-legend-shape graph-legend-shape--category" aria-hidden="true"></span>
                 Categories
             </span>
         </div>
 
-        <button class="graph-fullscreen-btn" id="graph-fullscreen-btn" type="button"
-                aria-label="Toggle full-page graph view" aria-pressed="false">
-            <span class="graph-fullscreen-enter">&#x26F6; Full screen</span>
-            <span class="graph-fullscreen-exit">&#x2715; Exit full screen</span>
-        </button>
+        <div class="graph-controls">
+            {% if with_related %}
+            <div class="graph-mode-selector" id="graph-mode-selector">
+                <button class="graph-mode-btn graph-mode-btn--active" id="graph-mode-standard" type="button" aria-pressed="true">Standard</button>
+                <button class="graph-mode-btn" id="graph-mode-related" type="button" aria-pressed="false">Related</button>
+            </div>
+            {% endif %}
+
+            <button class="graph-fullscreen-btn" id="graph-fullscreen-btn" type="button"
+                    aria-label="Toggle full-page graph view" aria-pressed="false">
+                <span class="graph-fullscreen-enter">&#x26F6; Full screen</span>
+                <span class="graph-fullscreen-exit">&#x2715; Exit full screen</span>
+            </button>
+        </div>
     </div>
 
     <div class="graph-container" id="graph-container"
@@ -46,6 +55,11 @@
         Drag a node to pin it in place.</p>
 </div>
 
-<script>window.GRAPH_DATA = {{ graph_data_json | safe }};</script>
+<script>
+    window.GRAPH_DATA = {{ graph_data_json | safe }};
+    {% if with_related and related_graph_data_json %}
+    window.RELATED_GRAPH_DATA = {{ related_graph_data_json | safe }};
+    {% endif %}
+</script>
 <script src="{{ graph_js_url }}"></script>
 {% endblock %}

--- a/src/blogmore/templates/static/graph.css
+++ b/src/blogmore/templates/static/graph.css
@@ -62,7 +62,52 @@
     clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
 }
 
-/* ---- Fullscreen toggle button -------------------------------------------- */
+/* ---- Graph mode selector ------------------------------------------------- */
+
+.graph-mode-selector {
+    display: flex;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    overflow: hidden;
+    background: var(--bg-color, #fff);
+}
+
+.graph-mode-btn {
+    padding: 3px 12px;
+    font-size: 0.8em;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    color: var(--text-color, #333);
+    white-space: nowrap;
+    outline: none;
+    transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.graph-mode-btn:not(.graph-mode-btn--active):hover {
+    background: var(--border-color-light, var(--border-color));
+}
+
+.graph-mode-btn.graph-mode-btn--active {
+    background: var(--link-color, #4299e1);
+    color: #fff;
+    cursor: default;
+}
+
+/* Hide tag and category legend items when in related-mode */
+.graph-page--related-mode #graph-legend-tags,
+.graph-page--related-mode #graph-legend-categories {
+    display: none !important;
+}
+
+/* ---- Fullscreen toggle button & controls --------------------------------- */
+
+.graph-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-left: auto;
+}
 
 .graph-fullscreen-btn {
     padding: 3px 10px;
@@ -74,7 +119,6 @@
     color: var(--text-color, #333);
     white-space: nowrap;
     flex-shrink: 0;
-    margin-left: auto;
 }
 
 .graph-fullscreen-btn:hover {

--- a/src/blogmore/templates/static/graph.js
+++ b/src/blogmore/templates/static/graph.js
@@ -349,6 +349,52 @@
         });
     }
 
+    function setupModeSelector() {
+        var standardBtn = document.getElementById('graph-mode-standard');
+        var relatedBtn = document.getElementById('graph-mode-related');
+        var page = document.querySelector('.graph-page');
+
+        if (!standardBtn || !relatedBtn) { return; }
+
+        var relatedData = window.RELATED_GRAPH_DATA || { nodes: [], links: [] };
+
+        standardBtn.addEventListener('click', function () {
+            if (standardBtn.classList.contains('graph-mode-btn--active')) { return; }
+
+            standardBtn.classList.add('graph-mode-btn--active');
+            standardBtn.setAttribute('aria-pressed', 'true');
+            relatedBtn.classList.remove('graph-mode-btn--active');
+            relatedBtn.setAttribute('aria-pressed', 'false');
+
+            if (page) {
+                page.classList.remove('graph-page--related-mode');
+            }
+
+            switchGraphData(GRAPH_DATA);
+        });
+
+        relatedBtn.addEventListener('click', function () {
+            if (relatedBtn.classList.contains('graph-mode-btn--active')) { return; }
+
+            relatedBtn.classList.add('graph-mode-btn--active');
+            relatedBtn.setAttribute('aria-pressed', 'true');
+            standardBtn.classList.remove('graph-mode-btn--active');
+            standardBtn.setAttribute('aria-pressed', 'false');
+
+            if (page) {
+                page.classList.add('graph-page--related-mode');
+            }
+
+            switchGraphData(relatedData);
+        });
+    }
+
+    function switchGraphData(data) {
+        if (!graphInstance) { return; }
+        selectNode(null);
+        graphInstance.graphData(data);
+    }
+
     /* -------------------------------------------------------------------------
      * Script loading / bootstrap
      * ---------------------------------------------------------------------- */
@@ -392,6 +438,7 @@
     }
 
     setupFullscreenToggle();
+    setupModeSelector();
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', loadAndInit);

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from blogmore.graph import (
     GraphData,
     build_graph_data,
+    build_related_graph_data,
 )
 from blogmore.parser import Post, PostParser
 
@@ -438,6 +439,45 @@ class TestBuildGraphData:
             if link["source"] == "/a.html" and link["target"] == "/b.html"
         ]
         assert len(post_to_post) == 1
+
+
+class TestBuildRelatedGraphData:
+    """Tests for the build_related_graph_data function."""
+
+    def test_empty_posts_list(self) -> None:
+        """Empty post list produces a graph with no nodes or links."""
+        graph = build_related_graph_data([])
+        assert graph.nodes == []
+        assert graph.links == []
+
+    def test_post_nodes_created(self) -> None:
+        """Each post produces a node with type 'post'."""
+        posts = [
+            _make_post("post-a", "Content A", "/a.html", title="Post A"),
+            _make_post("post-b", "Content B", "/b.html", title="Post B"),
+        ]
+        graph = build_related_graph_data(posts)
+        post_nodes = [n for n in graph.nodes if n["type"] == "post"]
+        assert len(post_nodes) == 2
+        ids = {n["id"] for n in post_nodes}
+        assert "/a.html" in ids
+        assert "/b.html" in ids
+
+    def test_related_posts_edges(self) -> None:
+        """Edges are created between posts based on their relatedness."""
+        post_a = _make_post("post-a", "Content A", "/a.html", title="Post A")
+        post_b = _make_post("post-b", "Content B", "/b.html", title="Post B")
+        post_c = _make_post("post-c", "Content C", "/c.html", title="Post C")
+
+        # Set up related posts manually to mock similarity calculations
+        post_a.related_posts = [post_b, post_c]
+        post_b.related_posts = [post_a]
+
+        graph = build_related_graph_data([post_a, post_b, post_c])
+
+        assert len(graph.links) == 2
+        assert {"source": "/a.html", "target": "/b.html"} in graph.links
+        assert {"source": "/a.html", "target": "/c.html"} in graph.links
 
 
 ### test_graph.py ends here


### PR DESCRIPTION
Connectedness via category and tags, as before:

<img width="1278" height="1032" alt="Screenshot 2026-05-27 at 09 35 31" src="https://github.com/user-attachments/assets/0bbc2749-115b-4edb-9279-cf999927a9e6" />

this adds an optional relatedness view:

<img width="1280" height="1030" alt="Screenshot 2026-05-27 at 09 35 11" src="https://github.com/user-attachments/assets/5a4ea39a-0f2f-4d18-ad27-e1bff3cdc132" />
