### PR TITLE
Add support for an optional responsive ToC for posts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,11 @@
   wider displays, or as a collapsible inline list on narrow displays. Also
   added support for a `show_toc` frontmatter property (on by default).
   ([#588](https://github.com/davep/blogmore/pull/588))
+- Added support for a `show_toc_inline` configuration option and frontmatter
+  property (on by default) to control whether the inline collapsible Table of
+  Contents appears on narrow displays when `show_toc` is enabled.
+  ([#589](https://github.com/davep/blogmore/pull/589))
+
 
 ## v2.37.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@
   categories, external links, word counts, lifespan, streaks) with commas
   when they run into the thousands.
   ([#586](https://github.com/davep/blogmore/pull/586))
+- Added a responsive table of contents display, which floats to the right on
+  wider displays, or as a collapsible inline list on narrow displays. Also
+  added support for a `show_toc` frontmatter property (on by default).
+  ([#588](https://github.com/davep/blogmore/pull/588))
 
 ## v2.37.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,15 +8,11 @@
   categories, external links, word counts, lifespan, streaks) with commas
   when they run into the thousands.
   ([#586](https://github.com/davep/blogmore/pull/586))
-- Added a responsive table of contents display, which floats to the right on
-  wider displays, or as a collapsible inline list on narrow displays. Also
-  added support for a `show_toc` frontmatter property (on by default).
+- Added a responsive table of contents display to posts and pages, which
+  floats to the right on wider displays, or as a collapsible inline list on
+  narrow displays. Also added support for `show_toc` and `show_toc_inline`
+  frontmatter properties (on by default).
   ([#588](https://github.com/davep/blogmore/pull/588))
-- Added support for a `show_toc_inline` configuration option and frontmatter
-  property (on by default) to control whether the inline collapsible Table of
-  Contents appears on narrow displays when `show_toc` is enabled.
-  ([#589](https://github.com/davep/blogmore/pull/589))
-
 
 ## v2.37.0
 

--- a/blogmore.yaml.example
+++ b/blogmore.yaml.example
@@ -37,6 +37,10 @@ site_url: "https://example.com"
 # Optional: Include posts marked as drafts (default: false)
 include_drafts: false
 
+# Optional: Whether to show the Table of Contents on posts by default (default: true)
+# Can be overridden per-post with show_toc: true/false in frontmatter.
+show_toc: true
+
 # Optional: Remove the output directory before generating the site (default: false)
 clean_first: false
 

--- a/blogmore.yaml.example
+++ b/blogmore.yaml.example
@@ -41,6 +41,10 @@ include_drafts: false
 # Can be overridden per-post with show_toc: true/false in frontmatter.
 show_toc: true
 
+# Optional: Whether to show the inline/collapsed Table of Contents on narrow screens by default (default: true)
+# Can be overridden per-post with show_toc_inline: true/false in frontmatter.
+show_toc_inline: true
+
 # Optional: Remove the output directory before generating the site (default: false)
 clean_first: false
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -213,6 +213,22 @@ include_drafts: false
 include_drafts: true
 ```
 
+#### `show_toc`
+
+Whether to show the Table of Contents on posts by default. This sets the global default for all posts. It can be overridden per-post by setting `show_toc: true` or `show_toc: false` in individual post frontmatter.
+
+**Type:** Boolean  
+**Default:** `true`
+
+```yaml
+show_toc: true
+```
+
+```yaml
+# Disable Table of Contents globally by default
+show_toc: false
+```
+
 #### `clean_first`
 
 Remove the output directory before generating the site. Ensures no stale files remain from previous builds.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,6 +229,25 @@ show_toc: true
 show_toc: false
 ```
 
+#### `show_toc_inline`
+
+Whether to show the inline/collapsed Table of Contents on narrow screens by default. This sets the global default for all posts. It can be overridden per-post by setting `show_toc_inline: true` or `show_toc_inline: false` in individual post frontmatter.
+
+Note that `show_toc` controls whether a Table of Contents is shown at all. If `show_toc` is `true` and `show_toc_inline` is `false`, the floating sidebar Table of Contents will be shown on wide screens as normal, but the inline version will not be displayed on narrow screens.
+
+**Type:** Boolean  
+**Default:** `true`
+
+```yaml
+show_toc_inline: true
+```
+
+```yaml
+# Disable inline/collapsed Table of Contents globally by default
+show_toc_inline: false
+```
+
+
 #### `clean_first`
 
 Remove the output directory before generating the site. Ensures no stale files remain from previous builds.

--- a/docs/template-api.md
+++ b/docs/template-api.md
@@ -154,6 +154,9 @@ and `next_post`.
 | `gfi` | `float` (property) | Gunning Fog Index score for the post. |
 | `modified_date` | `datetime \| None` (property) | Last-modified datetime from metadata, if set. |
 | `related_posts` | `list[Post]` | List of related Post objects calculated via TF-IDF (populated when `with_related` is enabled). |
+| `toc_html` | `str` | Rendered HTML block containing the post's Table of Contents. |
+| `show_toc` | `bool` | `True` when the post should display a Table of Contents (can be disabled via frontmatter). |
+| `has_toc` | `bool` (property) | `True` when the post has a non-empty Table of Contents (i.e. contains headings and `show_toc` is enabled). |
 
 Helper methods available on `Post`:
 
@@ -386,6 +389,11 @@ The following CSS classes are part of the stable template/CSS contract:
 | `.post-content` | `div` | Rendered post/page HTML body. |
 | `.post-summary` | `article` | A single post card on a listing page. |
 | `.post-navigation` | `nav` | Previous/next post links. |
+| `.post-toc-container-mobile` | `aside` | Collapsible inline container for post TOC on small viewports. |
+| `.post-toc-container-desktop` | `aside` | Floating sticky container for post TOC on large viewports. |
+| `.post-toc-details` | `details` | Collapsible details element for responsive post TOC. |
+| `.post-toc-summary` | `summary` | Table of Contents title and toggle button. |
+| `.post-toc` | `nav` | Navigation element containing the TOC links list. |
 | `.pagination` | `nav` | Page navigation on listing pages. |
 | `.archive-post-count` | `span` | Parenthetical post count in archive headings (h1/h2/h3). |
 | `.archive-toc-count` | `span` | Parenthetical numeric count in the archive TOC sidebar. |

--- a/docs/template-api.md
+++ b/docs/template-api.md
@@ -238,6 +238,10 @@ be misleading.
 | `slug` | `str` (property) | URL slug derived from filename. |
 | `url` | `str` (property) | URL path (e.g. `/about.html`). |
 | `description` | `str` (property) | Page description (from metadata or first paragraph). |
+| `toc_html` | `str` | Rendered HTML block containing the page's Table of Contents. |
+| `show_toc` | `bool` | `True` when the page should display a Table of Contents (can be disabled via frontmatter). |
+| `show_toc_inline` | `bool` | `True` when the page should display the inline Table of Contents on narrow screens (can be disabled via frontmatter). |
+| `has_toc` | `bool` (property) | `True` when the page has a non-empty Table of Contents (i.e. contains headings and `show_toc` is enabled). |
 
 ## Backlink object
 

--- a/docs/template-api.md
+++ b/docs/template-api.md
@@ -156,7 +156,9 @@ and `next_post`.
 | `related_posts` | `list[Post]` | List of related Post objects calculated via TF-IDF (populated when `with_related` is enabled). |
 | `toc_html` | `str` | Rendered HTML block containing the post's Table of Contents. |
 | `show_toc` | `bool` | `True` when the post should display a Table of Contents (can be disabled via frontmatter). |
+| `show_toc_inline` | `bool` | `True` when the post should display the inline Table of Contents on narrow screens (can be disabled via frontmatter). |
 | `has_toc` | `bool` (property) | `True` when the post has a non-empty Table of Contents (i.e. contains headings and `show_toc` is enabled). |
+
 
 Helper methods available on `Post`:
 

--- a/docs/writing_a_page.md
+++ b/docs/writing_a_page.md
@@ -112,6 +112,23 @@ The Twitter/X handle of the site. Used in Twitter Card meta tags.
 twitter_site: "@my_blog"
 ```
 
+#### `show_toc`
+
+Whether to show the Table of Contents for this page. If not specified, this defaults to the global [`show_toc`](configuration.md#show_toc) setting in your configuration (which itself defaults to `true`). Set to `false` to hide the Table of Contents on this specific page even if it contains headings, or to `true` to show it.
+
+```yaml
+show_toc: false
+```
+
+#### `show_toc_inline`
+
+Whether to show the inline/collapsed Table of Contents on narrow screens for this page. If not specified, this defaults to the global [`show_toc_inline`](configuration.md#show_toc_inline) setting in your configuration (which itself defaults to `true`). Set to `false` to hide the inline Table of Contents on narrow displays for this specific page (while still showing the floating sidebar Table of Contents on wider displays, provided `show_toc` is enabled).
+
+```yaml
+show_toc_inline: false
+```
+
+
 ## The special case of `404.md`
 
 Many hosting services, including GitHub Pages, support a custom 404 page that is shown whenever a visitor tries to access a URL that doesn't exist on your site. BlogMore has built-in support for this.

--- a/docs/writing_a_post.md
+++ b/docs/writing_a_post.md
@@ -181,6 +181,15 @@ Whether to show the Table of Contents for this post. If not specified, this defa
 show_toc: false
 ```
 
+#### `show_toc_inline`
+
+Whether to show the inline/collapsed Table of Contents on narrow screens for this post. If not specified, this defaults to the global [`show_toc_inline`](configuration.md#show_toc_inline) setting in your configuration (which itself defaults to `true`). Set to `false` to hide the inline Table of Contents on narrow displays for this specific post (while still showing the floating sidebar Table of Contents on wider displays, provided `show_toc` is enabled).
+
+```yaml
+show_toc_inline: false
+```
+
+
 ### Date formats
 
 BlogMore accepts dates in several formats:
@@ -401,6 +410,10 @@ BlogMore automatically scans your post for all headings (`#` through `######`) a
 - **Disabling the TOC:** If you have headings but do not want a Table of Contents to be displayed at all (neither floating nor inline), you can disable it globally in your [configuration](configuration.md#show_toc) or set the `show_toc` property to `false` in the post's frontmatter:
   ```yaml
   show_toc: false
+  ```
+- **Disabling the inline TOC only:** If you want to keep the floating sidebar TOC on wider screens but hide the inline/collapsed TOC on narrow displays, you can disable it globally in your [configuration](configuration.md#show_toc_inline) or set the `show_toc_inline` property to `false` in the post's frontmatter:
+  ```yaml
+  show_toc_inline: false
   ```
 - The links target the automatically generated heading IDs (see [Heading IDs and anchor links](#heading-ids-and-anchor-links) above).
 - The generated list is automatically nested based on heading levels (e.g., `###` headings are nested under `##` headings).

--- a/docs/writing_a_post.md
+++ b/docs/writing_a_post.md
@@ -175,7 +175,7 @@ This key only has an effect when the comment invitation feature is enabled (eith
 
 #### `show_toc`
 
-Whether to show the Table of Contents for this post. Set to `true` by default. Set to `false` to hide the Table of Contents on this specific post even if it contains headings.
+Whether to show the Table of Contents for this post. If not specified, this defaults to the global [`show_toc`](configuration.md#show_toc) setting in your configuration (which itself defaults to `true`). Set to `false` to hide the Table of Contents on this specific post even if it contains headings, or to `true` to show it even if disabled globally.
 
 ```yaml
 show_toc: false
@@ -398,7 +398,7 @@ BlogMore automatically scans your post for all headings (`#` through `######`) a
 
 - **Sidebar & Responsive TOC:** By default, on desktop displays, a floating, sticky Table of Contents is shown in the right-hand margin of the page. On smaller mobile screens, this TOC is presented inline at the top of the post under a collapsible accordion.
 - **Manual TOC:** You can also insert the TOC manually at a specific place inside the post content by placing `[TOC]` on its own line.
-- **Disabling the TOC:** If you have headings but do not want a Table of Contents to be displayed at all (neither floating nor inline), you can set the `show_toc` property to `false` in the post's frontmatter:
+- **Disabling the TOC:** If you have headings but do not want a Table of Contents to be displayed at all (neither floating nor inline), you can disable it globally in your [configuration](configuration.md#show_toc) or set the `show_toc` property to `false` in the post's frontmatter:
   ```yaml
   show_toc: false
   ```

--- a/docs/writing_a_post.md
+++ b/docs/writing_a_post.md
@@ -173,6 +173,14 @@ invite_comments_to: "specific-address@example.com"
 
 This key only has an effect when the comment invitation feature is enabled (either globally via [`invite_comments`](configuration.md#invite_comments) or via the per-post `invite_comments` front-matter key above).
 
+#### `show_toc`
+
+Whether to show the Table of Contents for this post. Set to `true` by default. Set to `false` to hide the Table of Contents on this specific post even if it contains headings.
+
+```yaml
+show_toc: false
+```
+
 ### Date formats
 
 BlogMore accepts dates in several formats:
@@ -386,8 +394,14 @@ Here is an overview of what we will cover:
 
 #### How it works
 
-BlogMore automatically scans your post for all headings (`#` through `######`) and generates a nested list of links in place of the `[TOC]` marker. 
+BlogMore automatically scans your post for all headings (`#` through `######`) and generates a Table of Contents.
 
+- **Sidebar & Responsive TOC:** By default, on desktop displays, a floating, sticky Table of Contents is shown in the right-hand margin of the page. On smaller mobile screens, this TOC is presented inline at the top of the post under a collapsible accordion.
+- **Manual TOC:** You can also insert the TOC manually at a specific place inside the post content by placing `[TOC]` on its own line.
+- **Disabling the TOC:** If you have headings but do not want a Table of Contents to be displayed at all (neither floating nor inline), you can set the `show_toc` property to `false` in the post's frontmatter:
+  ```yaml
+  show_toc: false
+  ```
 - The links target the automatically generated heading IDs (see [Heading IDs and anchor links](#heading-ids-and-anchor-links) above).
 - The generated list is automatically nested based on heading levels (e.g., `###` headings are nested under `##` headings).
 - The table of contents is pre-styled to match your blog's theme, with hover effects and responsive indentation.

--- a/src/blogmore/__main__.py
+++ b/src/blogmore/__main__.py
@@ -228,6 +228,7 @@ def main() -> int:
             post_parser = PostParser(
                 site_url=site_config.site_url,
                 default_show_toc=site_config.show_toc,
+                default_show_toc_inline=site_config.show_toc_inline,
             )
             posts = post_parser.parse_directory(args.content_dir, include_drafts=True)
             for post in posts:
@@ -260,6 +261,7 @@ def main() -> int:
             post_parser = PostParser(
                 site_url=site_config.site_url,
                 default_show_toc=site_config.show_toc,
+                default_show_toc_inline=site_config.show_toc_inline,
             )
             posts = post_parser.parse_directory(
                 args.content_dir,
@@ -328,6 +330,7 @@ def main() -> int:
                 post_parser = PostParser(
                     site_url=site_config.site_url,
                     default_show_toc=site_config.show_toc,
+                    default_show_toc_inline=site_config.show_toc_inline,
                 )
                 posts = post_parser.parse_directory(
                     args.content_dir, include_drafts=site_config.include_drafts
@@ -346,6 +349,7 @@ def main() -> int:
                 post_parser = PostParser(
                     site_url=site_config.site_url,
                     default_show_toc=site_config.show_toc,
+                    default_show_toc_inline=site_config.show_toc_inline,
                 )
                 posts = post_parser.parse_directory(
                     args.content_dir, include_drafts=site_config.include_drafts

--- a/src/blogmore/__main__.py
+++ b/src/blogmore/__main__.py
@@ -225,7 +225,10 @@ def main() -> int:
         try:
             from blogmore.parser import PostParser
 
-            post_parser = PostParser(site_url=site_config.site_url)
+            post_parser = PostParser(
+                site_url=site_config.site_url,
+                default_show_toc=site_config.show_toc,
+            )
             posts = post_parser.parse_directory(args.content_dir, include_drafts=True)
             for post in posts:
                 if post.draft:
@@ -254,7 +257,10 @@ def main() -> int:
             from blogmore.generator.paths import resolve_post_output_paths
             from blogmore.parser import PostParser
 
-            post_parser = PostParser(site_url=site_config.site_url)
+            post_parser = PostParser(
+                site_url=site_config.site_url,
+                default_show_toc=site_config.show_toc,
+            )
             posts = post_parser.parse_directory(
                 args.content_dir,
                 include_drafts=site_config.include_drafts,
@@ -319,7 +325,10 @@ def main() -> int:
                 from blogmore.links import dump_external_links
                 from blogmore.parser import PostParser
 
-                post_parser = PostParser(site_url=site_config.site_url)
+                post_parser = PostParser(
+                    site_url=site_config.site_url,
+                    default_show_toc=site_config.show_toc,
+                )
                 posts = post_parser.parse_directory(
                     args.content_dir, include_drafts=site_config.include_drafts
                 )
@@ -334,7 +343,10 @@ def main() -> int:
                 from blogmore.links import check_external_links
                 from blogmore.parser import PostParser
 
-                post_parser = PostParser(site_url=site_config.site_url)
+                post_parser = PostParser(
+                    site_url=site_config.site_url,
+                    default_show_toc=site_config.show_toc,
+                )
                 posts = post_parser.parse_directory(
                     args.content_dir, include_drafts=site_config.include_drafts
                 )

--- a/src/blogmore/generator/site.py
+++ b/src/blogmore/generator/site.py
@@ -76,6 +76,7 @@ class SiteGenerator:
             site_url=self.site_config.site_url,
             image_manager=self.image_manager,
             content_dir=content_dir,
+            default_show_toc=self.site_config.show_toc,
         )
         self.renderer = TemplateRenderer(
             self.site_config.templates_dir,

--- a/src/blogmore/generator/site.py
+++ b/src/blogmore/generator/site.py
@@ -77,6 +77,7 @@ class SiteGenerator:
             image_manager=self.image_manager,
             content_dir=content_dir,
             default_show_toc=self.site_config.show_toc,
+            default_show_toc_inline=self.site_config.show_toc_inline,
         )
         self.renderer = TemplateRenderer(
             self.site_config.templates_dir,

--- a/src/blogmore/linter.py
+++ b/src/blogmore/linter.py
@@ -34,7 +34,10 @@ class Linter:
             site_config: The site configuration.
         """
         self.site_config = site_config
-        self.parser = PostParser(site_url=site_config.site_url)
+        self.parser = PostParser(
+            site_url=site_config.site_url,
+            default_show_toc=site_config.show_toc,
+        )
         self.errors = 0
         self.warnings = 0
 

--- a/src/blogmore/linter.py
+++ b/src/blogmore/linter.py
@@ -37,6 +37,7 @@ class Linter:
         self.parser = PostParser(
             site_url=site_config.site_url,
             default_show_toc=site_config.show_toc,
+            default_show_toc_inline=site_config.show_toc_inline,
         )
         self.errors = 0
         self.warnings = 0

--- a/src/blogmore/parser.py
+++ b/src/blogmore/parser.py
@@ -423,6 +423,7 @@ class PostParser:
         site_url: str | None = None,
         image_manager: Any = None,
         content_dir: Path | None = None,
+        default_show_toc: bool = True,
     ) -> None:
         """Initialize the parser with markdown extensions.
 
@@ -430,10 +431,12 @@ class PostParser:
             site_url: Optional base URL of the site for determining internal vs external links
             image_manager: Optional ImageManager instance for image optimisation.
             content_dir: Optional content directory for image optimisation.
+            default_show_toc: Whether to show the Table of Contents on posts by default.
         """
         self.site_url = site_url or ""
         self.image_manager = image_manager
         self.content_dir = content_dir
+        self.default_show_toc = default_show_toc
 
     @property
     def markdown(self) -> markdown.Markdown:
@@ -611,7 +614,10 @@ class PostParser:
         draft = bool(post_data.get("draft", False))
 
         # Check show_toc status
-        show_toc = bool(post_data.get("show_toc", True))
+        raw_show_toc = post_data.get("show_toc")
+        show_toc = (
+            bool(raw_show_toc) if raw_show_toc is not None else self.default_show_toc
+        )
 
         # Convert markdown to HTML
         try:

--- a/src/blogmore/parser.py
+++ b/src/blogmore/parser.py
@@ -377,6 +377,30 @@ class Page:
     url_path: str | None = field(default=None, repr=False, compare=False)
     """Pre-resolved custom URL path for this page, or `None` to use the default URL pattern."""
 
+    toc_html: str = field(default="", repr=False, compare=False)
+    """The HTML content of the Table of Contents."""
+
+    show_toc: bool = True
+    """Whether to show the Table of Contents on this page (enabled by default)."""
+
+    show_toc_inline: bool = True
+    """Whether to show the inline/collapsed Table of Contents on narrow screens (enabled by default)."""
+
+    @property
+    def has_toc(self) -> bool:
+        """Check if the page has a non-empty Table of Contents.
+
+        Returns:
+            True if the page has headings, the toc_html is not empty, and
+            show_toc is True.
+        """
+        if not self.show_toc:
+            return False
+        stripped = self.toc_html.strip()
+        if not stripped:
+            return False
+        return "<li>" in stripped
+
     @property
     def slug(self) -> str:
         """Generate a URL slug from the page filename."""
@@ -731,9 +755,30 @@ class PostParser:
                 f"  Fix: wrap the value in quotes, e.g.  title: 'My Page Title'"
             )
 
+        # Check show_toc status
+        raw_show_toc = page_data.get("show_toc")
+        show_toc = (
+            bool(raw_show_toc) if raw_show_toc is not None else self.default_show_toc
+        )
+
+        # Check show_toc_inline status
+        raw_show_toc_inline = page_data.get("show_toc_inline")
+        show_toc_inline = (
+            bool(raw_show_toc_inline)
+            if raw_show_toc_inline is not None
+            else self.default_show_toc_inline
+        )
+
         # Convert markdown to HTML
         try:
+            # If the optimised images extension is active, tell it which
+            # directory we are currently in so it can resolve relative images.
+            for ext in self.markdown.registeredExtensions:
+                if hasattr(ext, "set_base_dir"):
+                    ext.set_base_dir(path.parent)
+
             html_content = self.markdown.convert(page_data.content)
+            toc_html = getattr(self.markdown, "toc", "")
         finally:
             self.markdown.reset()
 
@@ -743,6 +788,9 @@ class PostParser:
             content=page_data.content,
             html_content=html_content,
             metadata=dict(page_data.metadata),
+            toc_html=toc_html,
+            show_toc=show_toc,
+            show_toc_inline=show_toc_inline,
         )
 
     def parse_pages_directory(self, directory: Path) -> list[Page]:

--- a/src/blogmore/parser.py
+++ b/src/blogmore/parser.py
@@ -165,6 +165,23 @@ class Post:
     related_posts: list[Post] = field(default_factory=list, repr=False, compare=False)
     """A list of other [`Post`][blogmore.parser.Post] objects that are related to this post."""
 
+    toc_html: str = field(default="", repr=False, compare=False)
+    """The generated Table of Contents HTML for the post, if any."""
+
+    show_toc: bool = True
+    """Whether to show the Table of Contents on this post (enabled by default)."""
+
+    @property
+    def has_toc(self) -> bool:
+        """Check if the post has a non-empty Table of Contents.
+
+        Returns:
+            True if the post has a Table of Contents with items, False otherwise.
+        """
+        if not self.show_toc:
+            return False
+        return bool(self.toc_html and "<li>" in self.toc_html)
+
     @property
     def slug(self) -> str:
         """Generate a URL slug from the post filename."""
@@ -593,6 +610,9 @@ class PostParser:
         # Check draft status
         draft = bool(post_data.get("draft", False))
 
+        # Check show_toc status
+        show_toc = bool(post_data.get("show_toc", True))
+
         # Convert markdown to HTML
         try:
             # If the optimised images extension is active, tell it which
@@ -602,6 +622,7 @@ class PostParser:
                     ext.set_base_dir(path.parent)
 
             html_content = self.markdown.convert(post_data.content)
+            toc_html = getattr(self.markdown, "toc", "")
         finally:
             self.markdown.reset()
 
@@ -615,6 +636,8 @@ class PostParser:
             tags=tags,
             draft=draft,
             metadata=dict(post_data.metadata),
+            toc_html=toc_html,
+            show_toc=show_toc,
         )
 
     def parse_directory(

--- a/src/blogmore/parser.py
+++ b/src/blogmore/parser.py
@@ -171,6 +171,9 @@ class Post:
     show_toc: bool = True
     """Whether to show the Table of Contents on this post (enabled by default)."""
 
+    show_toc_inline: bool = True
+    """Whether to show the inline/collapsed Table of Contents on narrow screens (enabled by default)."""
+
     @property
     def has_toc(self) -> bool:
         """Check if the post has a non-empty Table of Contents.
@@ -424,6 +427,7 @@ class PostParser:
         image_manager: Any = None,
         content_dir: Path | None = None,
         default_show_toc: bool = True,
+        default_show_toc_inline: bool = True,
     ) -> None:
         """Initialize the parser with markdown extensions.
 
@@ -432,11 +436,13 @@ class PostParser:
             image_manager: Optional ImageManager instance for image optimisation.
             content_dir: Optional content directory for image optimisation.
             default_show_toc: Whether to show the Table of Contents on posts by default.
+            default_show_toc_inline: Whether to show the inline Table of Contents by default.
         """
         self.site_url = site_url or ""
         self.image_manager = image_manager
         self.content_dir = content_dir
         self.default_show_toc = default_show_toc
+        self.default_show_toc_inline = default_show_toc_inline
 
     @property
     def markdown(self) -> markdown.Markdown:
@@ -619,6 +625,14 @@ class PostParser:
             bool(raw_show_toc) if raw_show_toc is not None else self.default_show_toc
         )
 
+        # Check show_toc_inline status
+        raw_show_toc_inline = post_data.get("show_toc_inline")
+        show_toc_inline = (
+            bool(raw_show_toc_inline)
+            if raw_show_toc_inline is not None
+            else self.default_show_toc_inline
+        )
+
         # Convert markdown to HTML
         try:
             # If the optimised images extension is active, tell it which
@@ -644,6 +658,7 @@ class PostParser:
             metadata=dict(post_data.metadata),
             toc_html=toc_html,
             show_toc=show_toc,
+            show_toc_inline=show_toc_inline,
         )
 
     def parse_directory(

--- a/src/blogmore/site_config.py
+++ b/src/blogmore/site_config.py
@@ -298,6 +298,13 @@ class SiteConfig:
     command line.  On by default.
     """
 
+    show_toc_inline: bool = True
+    """Whether to show the inline/collapsed Table of Contents on narrow screens by default.
+
+    This is a **configuration file only** option — it cannot be set on the
+    command line.  On by default.
+    """
+
     post_path: str = DEFAULT_POST_PATH
     """Format string used to determine each post's output path and URL.
 

--- a/src/blogmore/site_config.py
+++ b/src/blogmore/site_config.py
@@ -291,6 +291,13 @@ class SiteConfig:
     include_drafts: bool = False
     """Whether to include draft posts in generation."""
 
+    show_toc: bool = True
+    """Whether to show the Table of Contents on posts by default.
+
+    This is a **configuration file only** option — it cannot be set on the
+    command line.  On by default.
+    """
+
     post_path: str = DEFAULT_POST_PATH
     """Format string used to determine each post's output path and URL.
 

--- a/src/blogmore/templates/page.html
+++ b/src/blogmore/templates/page.html
@@ -19,6 +19,28 @@
         <a class="u-url" href="{{ page.url }}" style="display:none;">Permalink</a>
     </header>
     
+    {% if page.has_toc and page.show_toc_inline %}
+    <!-- Mobile/Tablet Table of Contents (Inline, Collapsible) -->
+    <aside class="post-toc-container-mobile">
+        <details class="post-toc-details">
+            <summary class="post-toc-summary">Table of Contents</summary>
+            <nav class="post-toc" aria-label="Page table of contents">
+                {{ page.toc_html|safe }}
+            </nav>
+        </details>
+    </aside>
+    {% endif %}
+
+    {% if page.has_toc %}
+    <!-- Desktop Table of Contents (Floating, Sticky) -->
+    <aside class="post-toc-container-desktop">
+        <div class="post-toc-title">Table of Contents</div>
+        <nav class="post-toc" aria-label="Page table of contents">
+            {{ page.toc_html|safe }}
+        </nav>
+    </aside>
+    {% endif %}
+
     <div class="e-content page-content post-content">
         {{ page.html_content|safe }}
     </div>

--- a/src/blogmore/templates/post.html
+++ b/src/blogmore/templates/post.html
@@ -72,6 +72,26 @@
         {% endif %}
     </header>
     
+    {% if post.has_toc %}
+    <!-- Mobile/Tablet Table of Contents (Inline, Collapsible) -->
+    <aside class="post-toc-container-mobile">
+        <details class="post-toc-details">
+            <summary class="post-toc-summary">Table of Contents</summary>
+            <nav class="post-toc" aria-label="Post table of contents">
+                {{ post.toc_html|safe }}
+            </nav>
+        </details>
+    </aside>
+
+    <!-- Desktop Table of Contents (Floating, Sticky) -->
+    <aside class="post-toc-container-desktop">
+        <div class="post-toc-title">Table of Contents</div>
+        <nav class="post-toc" aria-label="Post table of contents">
+            {{ post.toc_html|safe }}
+        </nav>
+    </aside>
+    {% endif %}
+    
     <div class="e-content post-content">
         {{ post.html_content|safe }}
     </div>

--- a/src/blogmore/templates/post.html
+++ b/src/blogmore/templates/post.html
@@ -72,7 +72,7 @@
         {% endif %}
     </header>
     
-    {% if post.has_toc %}
+    {% if post.has_toc and post.show_toc_inline %}
     <!-- Mobile/Tablet Table of Contents (Inline, Collapsible) -->
     <aside class="post-toc-container-mobile">
         <details class="post-toc-details">
@@ -82,7 +82,9 @@
             </nav>
         </details>
     </aside>
+    {% endif %}
 
+    {% if post.has_toc %}
     <!-- Desktop Table of Contents (Floating, Sticky) -->
     <aside class="post-toc-container-desktop">
         <div class="post-toc-title">Table of Contents</div>

--- a/src/blogmore/templates/static/style.css
+++ b/src/blogmore/templates/static/style.css
@@ -1313,6 +1313,109 @@ footer a:hover {
 }
 
 /* =============================================================================
+   POST TABLE OF CONTENTS
+   ============================================================================= */
+
+/* Container for mobile table of contents */
+.post-toc-container-mobile {
+    margin: 1.5em 0;
+    padding: 12px 16px;
+    background: var(--code-bg);
+    border: 1px solid var(--border-color-light);
+    border-radius: 6px;
+}
+
+/* Hide desktop TOC by default */
+.post-toc-container-desktop {
+    display: none;
+}
+
+.post-toc-details {
+    outline: none;
+}
+
+.post-toc-summary {
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    color: var(--text-color);
+    outline: none;
+}
+
+.post-toc-summary:focus-visible {
+    outline: 2px solid var(--hover-color);
+}
+
+.post-toc-details nav.post-toc {
+    margin-top: 10px;
+    font-size: 0.9em;
+}
+
+.post-toc-details nav.post-toc ul,
+.post-toc-container-desktop nav.post-toc ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.post-toc-details nav.post-toc ul ul,
+.post-toc-container-desktop nav.post-toc ul ul {
+    padding-left: 16px;
+    margin-top: 4px;
+}
+
+.post-toc-details nav.post-toc li,
+.post-toc-container-desktop nav.post-toc li {
+    margin-bottom: 6px;
+}
+
+.post-toc-details nav.post-toc a,
+.post-toc-container-desktop nav.post-toc a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color 0.2s ease;
+    display: inline-block;
+}
+
+.post-toc-details nav.post-toc a:hover,
+.post-toc-container-desktop nav.post-toc a:hover {
+    color: var(--hover-color);
+}
+
+/* Floating Table of Contents for wide screens */
+@media (min-width: 1280px) {
+    /* Hide mobile TOC on desktop */
+    .post-toc-container-mobile {
+        display: none;
+    }
+
+    /* Show and float desktop TOC */
+    .post-toc-container-desktop {
+        display: block;
+        position: fixed;
+        left: calc(280px + 800px + 20px);
+        top: 20px;
+        width: 180px;
+        max-height: calc(100vh - 40px);
+        overflow-y: auto;
+    }
+
+    .post-toc-title {
+        font-weight: 600;
+        font-size: 0.9em;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-secondary);
+        margin-bottom: 8px;
+    }
+
+    .post-toc-container-desktop nav.post-toc a {
+        font-size: 0.9em;
+        line-height: 1.3;
+    }
+}
+
+/* =============================================================================
    THEME TOGGLE
    ============================================================================= */
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1160,6 +1160,7 @@ This post has [an external link](https://external.com) and
         assert "heading-1" in post.toc_html
         assert "heading-2" in post.toc_html
         assert post.show_toc is True
+        assert post.show_toc_inline is True
         assert post.has_toc is True
 
         # Post with headings but show_toc: false (should not have TOC shown)
@@ -1174,7 +1175,19 @@ This post has [an external link](https://external.com) and
         post_disabled = parser.parse_file(post_show_toc_false)
         assert post_disabled.toc_html != ""  # Markdown generates it internally
         assert post_disabled.show_toc is False
+        assert post_disabled.show_toc_inline is True
         assert post_disabled.has_toc is False
+
+        # Post with show_toc_inline: false
+        post_show_toc_inline_false = tmp_path / "show-toc-inline-false.md"
+        post_show_toc_inline_false.write_text(
+            "---\ntitle: Post with show_toc_inline False\nshow_toc_inline: false\n---\n\n"
+            "# Heading 1\n"
+        )
+        post_inline_disabled = parser.parse_file(post_show_toc_inline_false)
+        assert post_inline_disabled.show_toc is True
+        assert post_inline_disabled.show_toc_inline is False
+        assert post_inline_disabled.has_toc is True
 
         # Test with custom default_show_toc=False
         parser_disabled_by_default = PostParser(default_show_toc=False)
@@ -1182,7 +1195,29 @@ This post has [an external link](https://external.com) and
             post_with_headings
         )
         assert post_default_disabled.show_toc is False
+        assert post_default_disabled.show_toc_inline is True
         assert post_default_disabled.has_toc is False
+
+        # Test with custom default_show_toc_inline=False
+        parser_inline_disabled_by_default = PostParser(default_show_toc_inline=False)
+        post_default_inline_disabled = parser_inline_disabled_by_default.parse_file(
+            post_with_headings
+        )
+        assert post_default_inline_disabled.show_toc is True
+        assert post_default_inline_disabled.show_toc_inline is False
+        assert post_default_inline_disabled.has_toc is True
+
+        # Post with show_toc_inline: true overriding the default False
+        post_override_inline_true = tmp_path / "override-inline-true.md"
+        post_override_inline_true.write_text(
+            "---\ntitle: Override Inline True\nshow_toc_inline: true\n---\n\n# Heading 1\nContent\n"
+        )
+        post_override_inline = parser_inline_disabled_by_default.parse_file(
+            post_override_inline_true
+        )
+        assert post_override_inline.show_toc is True
+        assert post_override_inline.show_toc_inline is True
+        assert post_override_inline.has_toc is True
 
         # Post with show_toc: true overriding the default False
         post_override_true = tmp_path / "override-true.md"
@@ -1191,6 +1226,7 @@ This post has [an external link](https://external.com) and
         )
         post_override = parser_disabled_by_default.parse_file(post_override_true)
         assert post_override.show_toc is True
+        assert post_override.show_toc_inline is True
         assert post_override.has_toc is True
 
         # Post with no headings (should have an empty/meaningless TOC)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1176,6 +1176,23 @@ This post has [an external link](https://external.com) and
         assert post_disabled.show_toc is False
         assert post_disabled.has_toc is False
 
+        # Test with custom default_show_toc=False
+        parser_disabled_by_default = PostParser(default_show_toc=False)
+        post_default_disabled = parser_disabled_by_default.parse_file(
+            post_with_headings
+        )
+        assert post_default_disabled.show_toc is False
+        assert post_default_disabled.has_toc is False
+
+        # Post with show_toc: true overriding the default False
+        post_override_true = tmp_path / "override-true.md"
+        post_override_true.write_text(
+            "---\ntitle: Override True\nshow_toc: true\n---\n\n# Heading 1\nContent\n"
+        )
+        post_override = parser_disabled_by_default.parse_file(post_override_true)
+        assert post_override.show_toc is True
+        assert post_override.has_toc is True
+
         # Post with no headings (should have an empty/meaningless TOC)
         post_no_headings = tmp_path / "no-headings.md"
         post_no_headings.write_text(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1141,6 +1141,72 @@ This post has [an external link](https://external.com) and
         assert "9:00am" in page.html_content
         assert "This is paragraph two." in page.html_content
 
+    def test_page_toc_generation(self, tmp_path: Path) -> None:
+        """Test that Table of Contents (TOC) is parsed and has_toc works correctly on Pages."""
+        parser = PostParser()
+
+        # Page with headings (should have a TOC)
+        page_with_headings = tmp_path / "page-with-headings.md"
+        page_with_headings.write_text(
+            "---\ntitle: Page with Headings\n---\n\n"
+            "# Heading 1\n"
+            "Some content.\n\n"
+            "## Heading 2\n"
+            "More content.\n"
+        )
+        page = parser.parse_page(page_with_headings)
+        assert page.toc_html != ""
+        assert "<li>" in page.toc_html
+        assert "heading-1" in page.toc_html
+        assert "heading-2" in page.toc_html
+        assert page.show_toc is True
+        assert page.show_toc_inline is True
+        assert page.has_toc is True
+
+        # Page with headings but show_toc: false (should not have TOC shown)
+        page_show_toc_false = tmp_path / "page-show-toc-false.md"
+        page_show_toc_false.write_text(
+            "---\ntitle: Page with show_toc False\nshow_toc: false\n---\n\n"
+            "# Heading 1\n"
+            "Some content.\n\n"
+            "## Heading 2\n"
+            "More content.\n"
+        )
+        page_disabled = parser.parse_page(page_show_toc_false)
+        assert page_disabled.toc_html != ""  # Markdown generates it internally
+        assert page_disabled.show_toc is False
+        assert page_disabled.show_toc_inline is True
+        assert page_disabled.has_toc is False
+
+        # Page with show_toc_inline: false
+        page_show_toc_inline_false = tmp_path / "page-show-toc-inline-false.md"
+        page_show_toc_inline_false.write_text(
+            "---\ntitle: Page with show_toc_inline False\nshow_toc_inline: false\n---\n\n"
+            "# Heading 1\n"
+        )
+        page_inline_disabled = parser.parse_page(page_show_toc_inline_false)
+        assert page_inline_disabled.show_toc is True
+        assert page_inline_disabled.show_toc_inline is False
+        assert page_inline_disabled.has_toc is True
+
+        # Test with custom default_show_toc=False
+        parser_disabled_by_default = PostParser(default_show_toc=False)
+        page_default_disabled = parser_disabled_by_default.parse_page(
+            page_with_headings
+        )
+        assert page_default_disabled.show_toc is False
+        assert page_default_disabled.show_toc_inline is True
+        assert page_default_disabled.has_toc is False
+
+        # Test with custom default_show_toc_inline=False
+        parser_inline_disabled_by_default = PostParser(default_show_toc_inline=False)
+        page_default_inline_disabled = parser_inline_disabled_by_default.parse_page(
+            page_with_headings
+        )
+        assert page_default_inline_disabled.show_toc is True
+        assert page_default_inline_disabled.show_toc_inline is False
+        assert page_default_inline_disabled.has_toc is True
+
     def test_post_toc_generation(self, tmp_path: Path) -> None:
         """Test that Table of Contents (TOC) is parsed and has_toc works correctly."""
         parser = PostParser()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1140,3 +1140,50 @@ This post has [an external link](https://external.com) and
 
         assert "9:00am" in page.html_content
         assert "This is paragraph two." in page.html_content
+
+    def test_post_toc_generation(self, tmp_path: Path) -> None:
+        """Test that Table of Contents (TOC) is parsed and has_toc works correctly."""
+        parser = PostParser()
+
+        # Post with headings (should have a TOC)
+        post_with_headings = tmp_path / "with-headings.md"
+        post_with_headings.write_text(
+            "---\ntitle: Post with Headings\n---\n\n"
+            "# Heading 1\n"
+            "Some content.\n\n"
+            "## Heading 2\n"
+            "More content.\n"
+        )
+        post = parser.parse_file(post_with_headings)
+        assert post.toc_html != ""
+        assert "<li>" in post.toc_html
+        assert "heading-1" in post.toc_html
+        assert "heading-2" in post.toc_html
+        assert post.show_toc is True
+        assert post.has_toc is True
+
+        # Post with headings but show_toc: false (should not have TOC shown)
+        post_show_toc_false = tmp_path / "show-toc-false.md"
+        post_show_toc_false.write_text(
+            "---\ntitle: Post with show_toc False\nshow_toc: false\n---\n\n"
+            "# Heading 1\n"
+            "Some content.\n\n"
+            "## Heading 2\n"
+            "More content.\n"
+        )
+        post_disabled = parser.parse_file(post_show_toc_false)
+        assert post_disabled.toc_html != ""  # Markdown generates it internally
+        assert post_disabled.show_toc is False
+        assert post_disabled.has_toc is False
+
+        # Post with no headings (should have an empty/meaningless TOC)
+        post_no_headings = tmp_path / "no-headings.md"
+        post_no_headings.write_text(
+            "---\ntitle: Post without Headings\n---\n\n"
+            "Just some plain text content without any markdown headers.\n"
+        )
+        post_empty = parser.parse_file(post_no_headings)
+        # It might contain container tags like <div class="toc"><ul></ul></div> but no <li> elements
+        assert "<li>" not in post_empty.toc_html
+        assert post_empty.show_toc is True
+        assert post_empty.has_toc is False


### PR DESCRIPTION
When viewing a post that has one or more headings, provide a responsive ToC. On wider displays it uses the "dead space" on the right hand side of the post.

<img width="1534" height="1163" alt="Screenshot 2026-06-03 at 19 42 48" src="https://github.com/user-attachments/assets/8340303f-271f-483e-82cb-5aee3c55a52c" />

On a narrow display, the table moves inline, collapsed.

<img width="686" height="1163" alt="Screenshot 2026-06-03 at 19 43 00" src="https://github.com/user-attachments/assets/f78464ad-af88-4f19-a05f-c98f83863bb0" />

which the reader can then expand.

<img width="686" height="1163" alt="Screenshot 2026-06-03 at 19 43 07" src="https://github.com/user-attachments/assets/b2e54385-8d14-42d3-a301-031b322406d5" />
