### PR TITLE
Add support for page and post redirection

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # BlogMore ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Added support for URL aliases and path redirects using a `redirect_from`
+  list in post/page frontmatter.
+  ([#590](https://github.com/davep/blogmore/pull/590))
+
 ## v2.38.0
 
 **Released: 2026-06-04**

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ here](https://github.com/davep/davep.github.com)).
 - **Flexible post URL format** — fully configurable post output paths and URLs
   via the `post_path` option; choose date-based paths, per-post directories,
   category-based layouts, and more
+- **URL redirection** — redirect older or alternative URLs to posts and pages
+  using a `redirect_from` list in frontmatter
 - **Optional reading time display** — estimated reading time shown next to the
   post date, based on 200 words per minute
 - **GitHub-style admonitions** — alert boxes (note, tip, important, warning,

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ BlogMore focuses on simplicity and efficiency in creating blog-focused websites.
 - **Client-side search** - Optional full-text search across post titles and content, running entirely in the browser with no external services (enable with `--with-search`)
 - **XML sitemap** - Optional `sitemap.xml` generation for search engine indexing (enable with `--with-sitemap`)
 - **Flexible URL scheme for posts** - Fully configurable post output paths and URLs via the `post_path` option; choose date-based paths, per-post directories, category-based layouts, and more
+- **URL redirection** - Support for URL aliases and path redirects using a `redirect_from` list in post or page frontmatter
 - **Blog statistics page** — Optional stats page with histograms, word counts, reading times, lifespan, top linked domains, and more
 - **Calendar view** — Optional full-history year calendar view of all posts, with links to day, month, and year archives (enable with `--with-calendar`)
 - **Post graph** — optional interactive force-directed graph connecting posts, tags, and categories via internal links

--- a/docs/writing_a_page.md
+++ b/docs/writing_a_page.md
@@ -128,6 +128,27 @@ Whether to show the inline/collapsed Table of Contents on narrow screens for thi
 show_toc_inline: false
 ```
 
+#### `redirect_from`
+
+A list of URL paths (or a single URL path) that should redirect to this page. Fallback HTML redirection files containing a `<meta http-equiv="refresh" content="0; url=...">` redirect and a canonical link tag will be written at these alias paths during the build process.
+
+If the redirect path ends with a slash or has no extension, it will be treated as a directory and write an `index.html` file inside it. If it has a file extension (e.g. `.html` or `.htm`), it will write that file directly.
+
+Examples:
+
+```yaml
+# Redirect from legacy URLs
+redirect_from:
+  - /old-page/path
+  - /old-page/file.html
+```
+
+Or a single path:
+
+```yaml
+redirect_from: /old-page-slug
+```
+
 
 ## The special case of `404.md`
 

--- a/docs/writing_a_post.md
+++ b/docs/writing_a_post.md
@@ -189,6 +189,27 @@ Whether to show the inline/collapsed Table of Contents on narrow screens for thi
 show_toc_inline: false
 ```
 
+#### `redirect_from`
+
+A list of URL paths (or a single URL path) that should redirect to this post. Fallback HTML redirection files containing a `<meta http-equiv="refresh" content="0; url=...">` redirect and a canonical link tag will be written at these alias paths during the build process.
+
+If the redirect path ends with a slash or has no extension, it will be treated as a directory and write an `index.html` file inside it. If it has a file extension (e.g. `.html` or `.htm`), it will write that file directly.
+
+Examples:
+
+```yaml
+# Redirect from legacy URLs
+redirect_from:
+  - /2021/05/my-post/
+  - /old-category/my-post.html
+```
+
+Or a single path:
+
+```yaml
+redirect_from: /old-post-slug
+```
+
 
 ### Date formats
 

--- a/src/blogmore/generator/features.py
+++ b/src/blogmore/generator/features.py
@@ -254,17 +254,49 @@ class FeatureGenerator:
         if default_page.exists() and default_page != stale_page:
             default_page.unlink()
 
-    def generate_sitemap(self, extras_html_paths: frozenset[str]) -> None:
+    def generate_sitemap(
+        self,
+        extras_html_paths: frozenset[str],
+        posts: list[Post],
+        pages: list[Page],
+    ) -> None:
         """Generate the XML sitemap file.
 
         Args:
             extras_html_paths: Relative paths of HTML files copied from extras.
+            posts: All posts, used to extract redirect aliases.
+            pages: All pages, used to extract redirect aliases.
         """
+        from pathlib import Path
+
+        redirect_paths: set[str] = set()
+        items: list[Post | Page] = []
+        items.extend(posts)
+        items.extend(pages)
+
+        for item in items:
+            for alias in item.redirect_from:
+                alias = alias.strip()
+                if not alias:
+                    continue
+                clean_path = alias.lstrip("/")
+                if not clean_path:
+                    continue
+                path_obj = Path(clean_path)
+                rel_path = (
+                    (path_obj / "index.html").as_posix()
+                    if alias.endswith("/") or not path_obj.suffix
+                    else path_obj.as_posix()
+                )
+                redirect_paths.add(rel_path)
+
+        excluded_paths = extras_html_paths | frozenset(redirect_paths)
+
         write_sitemap(
             self.site_config.output_dir,
             self.site_config.site_url,
             clean_urls=self.site_config.clean_urls,
             search_path=self.site_config.search_path,
-            extra_excluded_paths=extras_html_paths,
+            extra_excluded_paths=excluded_paths,
             extra_urls=self.site_config.sitemap_extras,
         )

--- a/src/blogmore/generator/pages.py
+++ b/src/blogmore/generator/pages.py
@@ -126,6 +126,13 @@ class PageGenerator:
         html = self.renderer.render_post(post, **context)
         write_html(output_path, html, self.site_config.minify_html)
 
+        if post.redirect_from:
+            self._write_redirects(
+                post.redirect_from,
+                target_url=post.url,
+                canonical_url=context["canonical_url"],
+            )
+
     def generate_page(self, page: Page, pages: list[Page], output_path: Path) -> None:
         """Generate a single static page.
 
@@ -142,6 +149,13 @@ class PageGenerator:
 
         html = self.renderer.render_page(page, **context)
         write_html(output_path, html, self.site_config.minify_html)
+
+        if page.redirect_from:
+            self._write_redirects(
+                page.redirect_from,
+                target_url=page.url,
+                canonical_url=context["canonical_url"],
+            )
 
     def generate_404_page(self, page: Page, pages: list[Page]) -> None:
         """Generate the custom 404 page in the root of the output directory.
@@ -241,3 +255,48 @@ class PageGenerator:
             posts, page=1, total_pages=1, base_path="/archive", **context
         )
         write_html(output_path, html, self.site_config.minify_html)
+
+    def _write_redirects(
+        self, redirect_from: list[str], target_url: str, canonical_url: str
+    ) -> None:
+        """Write redirect files for the given alias paths.
+
+        Args:
+            redirect_from: List of alias URL paths.
+            target_url: Destination relative URL path for the redirection.
+            canonical_url: Fully-qualified canonical URL for the link tag.
+        """
+        for alias in redirect_from:
+            alias = alias.strip()
+            if not alias:
+                continue
+
+            clean_path = alias.lstrip("/")
+            if not clean_path:
+                continue
+
+            path_obj = Path(clean_path)
+
+            # Determine output file path based on directory or file form
+            if alias.endswith("/") or not path_obj.suffix:
+                output_path = self.site_config.output_dir / clean_path / "index.html"
+            else:
+                output_path = self.site_config.output_dir / clean_path
+
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            html = (
+                f"<!DOCTYPE html>\n"
+                f"<html>\n"
+                f"<head>\n"
+                f'    <meta charset="utf-8">\n'
+                f"    <title>Redirecting...</title>\n"
+                f'    <link rel="canonical" href="{canonical_url}">\n'
+                f'    <meta http-equiv="refresh" content="0; url={target_url}">\n'
+                f"</head>\n"
+                f"<body>\n"
+                f'    <p>Redirecting to <a href="{target_url}">{target_url}</a>...</p>\n'
+                f"</body>\n"
+                f"</html>\n"
+            )
+            write_html(output_path, html, self.site_config.minify_html)

--- a/src/blogmore/generator/site.py
+++ b/src/blogmore/generator/site.py
@@ -315,7 +315,9 @@ class SiteGenerator:
 
         if self.site_config.with_sitemap:
             with timed_step("Generating XML sitemap..."):
-                feature_gen.generate_sitemap(asset_manager.extras_html_paths)
+                feature_gen.generate_sitemap(
+                    asset_manager.extras_html_paths, posts, pages
+                )
 
         if self.image_manager:
             with timed_step("Deploying optimised responsive images..."):

--- a/src/blogmore/parser.py
+++ b/src/blogmore/parser.py
@@ -174,6 +174,9 @@ class Post:
     show_toc_inline: bool = True
     """Whether to show the inline/collapsed Table of Contents on narrow screens (enabled by default)."""
 
+    redirect_from: list[str] = field(default_factory=list, repr=False, compare=False)
+    """List of URL paths that should redirect to this post."""
+
     @property
     def has_toc(self) -> bool:
         """Check if the post has a non-empty Table of Contents.
@@ -385,6 +388,9 @@ class Page:
 
     show_toc_inline: bool = True
     """Whether to show the inline/collapsed Table of Contents on narrow screens (enabled by default)."""
+
+    redirect_from: list[str] = field(default_factory=list, repr=False, compare=False)
+    """List of URL paths that should redirect to this page."""
 
     @property
     def has_toc(self) -> bool:
@@ -657,6 +663,26 @@ class PostParser:
             else self.default_show_toc_inline
         )
 
+        # Extract redirect_from
+        raw_redirect_from = post_data.get("redirect_from", [])
+        if raw_redirect_from is None:
+            redirect_from: list[str] = []
+        elif isinstance(raw_redirect_from, str):
+            redirect_from = [
+                r.strip() for r in raw_redirect_from.split(",") if r.strip()
+            ]
+        elif isinstance(raw_redirect_from, list):
+            redirect_from = [
+                str(r).strip() for r in raw_redirect_from if str(r).strip()
+            ]
+        else:
+            raise ValueError(
+                f"Post 'redirect_from' in frontmatter must be a string or list in: {path}\n"
+                f"  Found: {raw_redirect_from!r} (type: {type(raw_redirect_from).__name__})\n"
+                f"  Fix: wrap the value in quotes or brackets, e.g. "
+                f" redirect_from: '/old-url'  or  redirect_from: [/old-url1, /old-url2]"
+            )
+
         # Convert markdown to HTML
         try:
             # If the optimised images extension is active, tell it which
@@ -683,6 +709,7 @@ class PostParser:
             toc_html=toc_html,
             show_toc=show_toc,
             show_toc_inline=show_toc_inline,
+            redirect_from=redirect_from,
         )
 
     def parse_directory(
@@ -769,6 +796,26 @@ class PostParser:
             else self.default_show_toc_inline
         )
 
+        # Extract redirect_from
+        raw_redirect_from = page_data.get("redirect_from", [])
+        if raw_redirect_from is None:
+            redirect_from: list[str] = []
+        elif isinstance(raw_redirect_from, str):
+            redirect_from = [
+                r.strip() for r in raw_redirect_from.split(",") if r.strip()
+            ]
+        elif isinstance(raw_redirect_from, list):
+            redirect_from = [
+                str(r).strip() for r in raw_redirect_from if str(r).strip()
+            ]
+        else:
+            raise ValueError(
+                f"Page 'redirect_from' in frontmatter must be a string or list in: {path}\n"
+                f"  Found: {raw_redirect_from!r} (type: {type(raw_redirect_from).__name__})\n"
+                f"  Fix: wrap the value in quotes or brackets, e.g. "
+                f" redirect_from: '/old-url'  or  redirect_from: [/old-url1, /old-url2]"
+            )
+
         # Convert markdown to HTML
         try:
             # If the optimised images extension is active, tell it which
@@ -791,6 +838,7 @@ class PostParser:
             toc_html=toc_html,
             show_toc=show_toc,
             show_toc_inline=show_toc_inline,
+            redirect_from=redirect_from,
         )
 
     def parse_pages_directory(self, directory: Path) -> list[Page]:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1306,3 +1306,48 @@ This post has [an external link](https://external.com) and
         assert "<li>" not in post_empty.toc_html
         assert post_empty.show_toc is True
         assert post_empty.has_toc is False
+
+    def test_parse_redirect_from_post(self, tmp_path: Path) -> None:
+        """Test that redirect_from list/string is parsed correctly for posts."""
+        parser = PostParser()
+        post_file = tmp_path / "redirect-post.md"
+        post_file.write_text(
+            "---\n"
+            "title: Post with Redirects\n"
+            "date: 2024-01-01\n"
+            "redirect_from:\n"
+            "  - /old-path/1\n"
+            "  - /old-path/2.html\n"
+            "---\n"
+            "Content"
+        )
+        post = parser.parse_file(post_file)
+        assert post.redirect_from == ["/old-path/1", "/old-path/2.html"]
+
+        post_file_str = tmp_path / "redirect-post-str.md"
+        post_file_str.write_text(
+            "---\n"
+            "title: Post with Redirect Str\n"
+            "date: 2024-01-01\n"
+            "redirect_from: /old-path/3\n"
+            "---\n"
+            "Content"
+        )
+        post_str = parser.parse_file(post_file_str)
+        assert post_str.redirect_from == ["/old-path/3"]
+
+    def test_parse_redirect_from_page(self, tmp_path: Path) -> None:
+        """Test that redirect_from list/string is parsed correctly for pages."""
+        parser = PostParser()
+        page_file = tmp_path / "redirect-page.md"
+        page_file.write_text(
+            "---\n"
+            "title: Page with Redirects\n"
+            "redirect_from:\n"
+            "  - /old-page/1\n"
+            "  - /old-page/2.html\n"
+            "---\n"
+            "Content"
+        )
+        page = parser.parse_page(page_file)
+        assert page.redirect_from == ["/old-page/1", "/old-page/2.html"]

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -51,6 +51,7 @@ def test_redirect_generation(tmp_path: Path) -> None:
             content_dir=content_dir,
             output_dir=output_dir,
             site_url="https://example.com",
+            with_sitemap=True,
         )
     )
     generator.generate()
@@ -116,3 +117,17 @@ def test_redirect_generation(tmp_path: Path) -> None:
     assert (
         '<link rel="canonical" href="https://example.com/redirect-page.html">' in html5
     )
+
+    # Verify that the redirect URLs are not in the sitemap
+    sitemap_path = output_dir / "sitemap.xml"
+    assert sitemap_path.exists()
+    sitemap_content = sitemap_path.read_text()
+    assert "old-post/path" not in sitemap_content
+    assert "old-post/path-with-slash" not in sitemap_content
+    assert "old-post/file.html" not in sitemap_content
+    assert "old-page/path" not in sitemap_content
+    assert "old-page/file.html" not in sitemap_content
+
+    # The actual post and page URLs should be in the sitemap
+    assert "2024/01/01/redirect-post.html" in sitemap_content
+    assert "redirect-page.html" in sitemap_content

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,0 +1,118 @@
+"""Tests for URL Aliases / Path Redirects (Migration Helper)."""
+
+from pathlib import Path
+
+from blogmore.generator import SiteGenerator
+from blogmore.site_config import SiteConfig
+
+
+def test_redirect_generation(tmp_path: Path) -> None:
+    """Test that post and page redirects are correctly generated.
+
+    Args:
+        tmp_path: The temporary path fixture provided by pytest.
+    """
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+
+    # Create a post with redirects
+    post_file = content_dir / "2024-01-01-redirect-post.md"
+    post_file.write_text(
+        "---\n"
+        "title: My Redirect Post\n"
+        "date: 2024-01-01\n"
+        "redirect_from:\n"
+        "  - /old-post/path\n"
+        "  - /old-post/path-with-slash/\n"
+        "  - /old-post/file.html\n"
+        "---\n"
+        "Post content."
+    )
+
+    # Create a page with redirects
+    pages_dir = content_dir / "pages"
+    pages_dir.mkdir()
+    page_file = pages_dir / "redirect-page.md"
+    page_file.write_text(
+        "---\n"
+        "title: My Redirect Page\n"
+        "redirect_from:\n"
+        "  - /old-page/path\n"
+        "  - /old-page/file.html\n"
+        "---\n"
+        "Page content."
+    )
+
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    generator = SiteGenerator(
+        site_config=SiteConfig(
+            content_dir=content_dir,
+            output_dir=output_dir,
+            site_url="https://example.com",
+        )
+    )
+    generator.generate()
+
+    # Verify that the post and page themselves were generated
+    assert (output_dir / "2024" / "01" / "01" / "redirect-post.html").exists()
+    assert (output_dir / "redirect-page.html").exists()
+
+    # Verify the redirect paths:
+    # 1. Post redirect: /old-post/path -> old-post/path/index.html (directory format)
+    redirect1_path = output_dir / "old-post" / "path" / "index.html"
+    assert redirect1_path.exists()
+    html1 = redirect1_path.read_text()
+    assert (
+        '<meta http-equiv="refresh" content="0; url=/2024/01/01/redirect-post.html">'
+        in html1
+    )
+    assert (
+        '<link rel="canonical" href="https://example.com/2024/01/01/redirect-post.html">'
+        in html1
+    )
+
+    # 2. Post redirect: /old-post/path-with-slash/ -> old-post/path-with-slash/index.html (directory format)
+    redirect2_path = output_dir / "old-post" / "path-with-slash" / "index.html"
+    assert redirect2_path.exists()
+    html2 = redirect2_path.read_text()
+    assert (
+        '<meta http-equiv="refresh" content="0; url=/2024/01/01/redirect-post.html">'
+        in html2
+    )
+    assert (
+        '<link rel="canonical" href="https://example.com/2024/01/01/redirect-post.html">'
+        in html2
+    )
+
+    # 3. Post redirect: /old-post/file.html -> old-post/file.html (file format)
+    redirect3_path = output_dir / "old-post" / "file.html"
+    assert redirect3_path.exists()
+    html3 = redirect3_path.read_text()
+    assert (
+        '<meta http-equiv="refresh" content="0; url=/2024/01/01/redirect-post.html">'
+        in html3
+    )
+    assert (
+        '<link rel="canonical" href="https://example.com/2024/01/01/redirect-post.html">'
+        in html3
+    )
+
+    # 4. Page redirect: /old-page/path -> old-page/path/index.html
+    redirect4_path = output_dir / "old-page" / "path" / "index.html"
+    assert redirect4_path.exists()
+    html4 = redirect4_path.read_text()
+    assert '<meta http-equiv="refresh" content="0; url=/redirect-page.html">' in html4
+    assert (
+        '<link rel="canonical" href="https://example.com/redirect-page.html">' in html4
+    )
+
+    # 5. Page redirect: /old-page/file.html -> old-page/file.html
+    redirect5_path = output_dir / "old-page" / "file.html"
+    assert redirect5_path.exists()
+    html5 = redirect5_path.read_text()
+    assert '<meta http-equiv="refresh" content="0; url=/redirect-page.html">' in html5
+    assert (
+        '<link rel="canonical" href="https://example.com/redirect-page.html">' in html5
+    )


### PR DESCRIPTION
Adds support for adding aliases for pages and posts, such that if someone visits the resulting URL, they'll be redirected to the page or post that the frontmatter is in. For example, a post with frontmatter like this:

```yaml
title: How to write classes in Python
date: 2006-06-03 08:30:11+0100
category: Coding
tags: Python, classes, howto
redirect_from:
  - /how-to-write-classes-in-python
  - /posts/2006/how-to-write-classes-in-python.html
  - /that/url/layout/from/back/in/the/day/post23.html
```

will result in the 3 URLs in the `redirect_from` list being implemented with a:

```html
<link href="https://example.com/2006/06/03/how-to-write-classes-in-python" rel="canonical">
<meta content="0; url=/2006/06/03/how-to-write-classes-in-python" http-equiv="refresh">
```

in the HTML, ensuring the correct canonical URL is declared and that an instant client-side redirection is done.