### PR TITLE
Add support for Mermaid diagrams

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # BlogMore ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Added Mermaid diagram rendering support via the `with_mermaid`
+  configuration option. ([#600](https://github.com/davep/blogmore/pull/600))
+
 ## v2.40.1
 
 **Released: 2026-06-06**

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ here](https://github.com/davep/davep.github.com)).
   tags, and categories via internal links; click any node to navigate to it;
   respects the active light/dark theme
 - **Related posts** — automatically find and display contextually relevant posts for each entry using a build-time TF-IDF and cosine similarity engine
+- **Diagrams (Mermaid)** — optional support for rendering Mermaid diagrams and flowcharts from fenced code blocks (enable with `with_mermaid: true` in configuration)
 - **SEO optimisation** — meta tags, Open Graph tags, and Twitter Card support
 - **Automatic organisation** — tag pages, category pages, and chronological
   archives generated automatically

--- a/blogmore.yaml.example
+++ b/blogmore.yaml.example
@@ -112,6 +112,13 @@ posts_per_feed: 20
 # bar automatically, between Calendar and RSS. Configuration file only.
 # with_graph: false
 
+# Optional: Enable Mermaid diagram rendering (default: false)
+# When true, BlogMore will support rendering diagrams written inside
+# fenced code blocks labeled with the 'mermaid' language tag.
+# To keep pages fast, the Mermaid library is only loaded on individual posts
+# and pages that actually contain a mermaid block. Configuration file only.
+# with_mermaid: false
+
 # Optional: Enable automated build-time related posts calculation (default: false)
 # When true, BlogMore uses a pure-Python TF-IDF and Cosine Similarity engine to
 # automatically find and display contextually relevant posts for each entry,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -499,6 +499,23 @@ Off by default.
 with_graph: true
 ```
 
+#### `with_mermaid`
+
+Enable Mermaid diagram rendering. When `true`, BlogMore will support rendering diagrams written inside fenced code blocks labeled with the `mermaid` language tag.
+
+To optimize page loading and keep builds fast, the Mermaid JS library is loaded dynamically from CDN only on pages (posts, pages, or index/listings) that actually contain a diagram block. 
+
+This is a **configuration file only** option — it cannot be set on the command line.
+
+Off by default.
+
+**Type:** Boolean  
+**Default:** `false`
+
+```yaml
+with_mermaid: true
+```
+
 #### `with_related`
 
 Enable automated build-time related posts calculation. When `true`, BlogMore uses a pure-Python TF-IDF and Cosine Similarity engine to automatically calculate and list contextually relevant posts for each entry, with zero runtime overhead for readers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ BlogMore focuses on simplicity and efficiency in creating blog-focused websites.
 - **Calendar view** — Optional full-history year calendar view of all posts, with links to day, month, and year archives (enable with `--with-calendar`)
 - **Post graph** — optional interactive force-directed graph connecting posts, tags, and categories via internal links
 - **Related posts** - Automatically find and display contextually relevant posts for each entry using a build-time TF-IDF and cosine similarity engine (enable with `--with-related`)
+- **Diagrams (Mermaid)** - Optional support for rendering Mermaid diagrams and flowcharts from fenced code blocks (enable with `with_mermaid: true` in your configuration)
 
 ## Installation
 

--- a/docs/template-api.md
+++ b/docs/template-api.md
@@ -57,6 +57,8 @@ below lists all variables that are available in every template.
 | `with_graph` | `bool` | `True` when the graph page is enabled. |
 | `graph_url` | `str` | URL to the graph page (respects `graph_path` and `clean_urls`). |
 | `graph_css_url` | `str` | URL to the graph-page stylesheet (with cache-bust query string). |
+| `with_mermaid` | `bool` | `True` when Mermaid diagram rendering is enabled. |
+| `has_mermaid` | `bool` | `True` if the currently rendered page/post (or any post listed in the current index view) contains a Mermaid diagram. |
 | `inline_theme_js` | `bool` | `True` when theme JavaScript inlining is enabled. |
 | `theme_js_content` | `str \| None` | The content of `theme.js` to be inlined. |
 | `theme_js_url` | `str` | URL to `theme.js` (with cache-bust query string). |

--- a/docs/writing_a_post.md
+++ b/docs/writing_a_post.md
@@ -336,6 +336,26 @@ def greet(name: str) -> str:
 
 A wide range of languages are supported, including `python`, `javascript`, `typescript`, `bash`, `yaml`, `json`, `html`, `css`, `sql`, `rust`, `go`, and many more.
 
+### Diagrams (Mermaid)
+
+If enabled, BlogMore supports rendering diagrams and flowcharts written inside fenced code blocks using the `mermaid` language identifier:
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B[Process]
+    B --> C{Decision}
+    C -->|Yes| D[Success]
+    C -->|No| E[Fail]
+```
+````
+
+To use Mermaid diagrams:
+
+* **Enable the feature:** You must turn on Mermaid rendering globally by setting [`with_mermaid: true`](configuration.md#with_mermaid) in your `blogmore.yaml` configuration file.
+* **Efficient loading:** To keep page load speeds fast, the Mermaid JS library is only loaded from a CDN on pages (posts, pages, or index/listings) that actually contain a diagram block.
+* **More options:** For full syntax details, layout options, and diagram types (such as sequence diagrams, pie charts, gantt charts, and user journeys), see the official [Mermaid documentation](https://mermaid.js.org/).
+
 ### Tables
 
 ```markdown

--- a/src/blogmore/generator/context.py
+++ b/src/blogmore/generator/context.py
@@ -240,6 +240,8 @@ class ContextBuilder:
             "calendar_url": self.get_calendar_url(),
             "with_graph": self.site_config.with_graph,
             "graph_url": self.get_graph_url(),
+            "with_mermaid": self.site_config.with_mermaid,
+            "has_mermaid": False,
             "with_read_time": self.site_config.with_read_time,
             "with_gfi": self.site_config.with_gfi,
             "with_backlinks": self.site_config.with_backlinks,

--- a/src/blogmore/markdown/extensions.py
+++ b/src/blogmore/markdown/extensions.py
@@ -9,6 +9,7 @@ from typing import Any
 from blogmore.markdown.admonitions import AdmonitionsExtension
 from blogmore.markdown.external_links import ExternalLinksExtension
 from blogmore.markdown.heading_anchors import HeadingAnchorsExtension
+from blogmore.markdown.mermaid import MermaidExtension
 from blogmore.markdown.optimised_images import OptimisedImagesExtension
 from blogmore.markdown.strikethrough import StrikethroughExtension
 
@@ -44,6 +45,7 @@ def create_custom_extensions(
         ExternalLinksExtension(site_url=site_url),
         HeadingAnchorsExtension(),
         StrikethroughExtension(),
+        MermaidExtension(),
     ]
     if with_optimised_images and image_manager is not None:
         extensions.append(

--- a/src/blogmore/markdown/mermaid.py
+++ b/src/blogmore/markdown/mermaid.py
@@ -1,0 +1,95 @@
+"""Markdown extension to support Mermaid diagrams.
+
+This module provides a custom preprocessor that intercepts fenced code blocks
+with the language 'mermaid' and outputs them as raw `<pre class="mermaid">`
+elements, stashed in the markdown HTML stash to prevent Pygments highlighting
+or escaping from codehilite.
+"""
+
+import html
+import re
+from typing import Any
+
+from markdown.extensions import Extension
+from markdown.preprocessors import Preprocessor
+
+
+class MermaidPreprocessor(Preprocessor):
+    """Preprocessor to handle fenced code blocks containing Mermaid diagrams.
+
+    Scans the source Markdown for fenced code blocks starting with ````mermaid`
+    and wraps the contained code in a `<pre class="mermaid">` tag. The content
+    is HTML-escaped and stashed in the HTML stash so it does not get processed
+    by subsequent Markdown extensions or code block highlighting.
+    """
+
+    FENCE_START = re.compile(r"^(\s*)```mermaid\s*$")
+    FENCE_END = re.compile(r"^\s*```\s*$")
+
+    def run(self, lines: list[str]) -> list[str]:
+        """Process markdown lines, converting mermaid blocks to HTML.
+
+        Args:
+            lines: The input lines of markdown.
+
+        Returns:
+            The processed lines with mermaid code blocks converted to stashed HTML.
+        """
+        new_lines: list[str] = []
+        in_mermaid = False
+        mermaid_lines: list[str] = []
+        indent = ""
+
+        for line in lines:
+            if not in_mermaid:
+                match = self.FENCE_START.match(line)
+                if match:
+                    in_mermaid = True
+                    indent = match.group(1)
+                    mermaid_lines = []
+                else:
+                    new_lines.append(line)
+            else:
+                if self.FENCE_END.match(line):
+                    in_mermaid = False
+                    code = "\n".join(mermaid_lines)
+                    escaped_code = html.escape(code)
+                    placeholder = self.md.htmlStash.store(
+                        f'<pre class="mermaid">{escaped_code}</pre>'
+                    )
+                    new_lines.append(indent + placeholder)
+                else:
+                    if line.startswith(indent):
+                        mermaid_lines.append(line[len(indent) :])
+                    else:
+                        mermaid_lines.append(line)
+
+        if in_mermaid:
+            new_lines.append(indent + "```mermaid")
+            new_lines.extend(mermaid_lines)
+
+        return new_lines
+
+
+class MermaidExtension(Extension):
+    """Markdown extension to support Mermaid diagrams."""
+
+    def extendMarkdown(self, md: Any) -> None:
+        """Register the mermaid preprocessor with the Markdown instance.
+
+        Args:
+            md: The Markdown instance to extend.
+        """
+        md.preprocessors.register(MermaidPreprocessor(md), "mermaid", 30)
+
+
+def makeExtension(**kwargs: Any) -> MermaidExtension:
+    """Create and return an instance of the MermaidExtension.
+
+    Args:
+        **kwargs: Configuration options.
+
+    Returns:
+        An instance of MermaidExtension.
+    """
+    return MermaidExtension(**kwargs)

--- a/src/blogmore/renderer.py
+++ b/src/blogmore/renderer.py
@@ -244,6 +244,10 @@ class TemplateRenderer:
         Returns:
             Rendered HTML string
         """
+        context["has_mermaid"] = (
+            'class="mermaid"' in post.html_content
+            or 'class="language-mermaid"' in post.html_content
+        )
         return self.render_template("post.html", post=post, **context)
 
     def render_page(self, page: Page, **context: Any) -> str:
@@ -256,6 +260,10 @@ class TemplateRenderer:
         Returns:
             Rendered HTML string
         """
+        context["has_mermaid"] = (
+            'class="mermaid"' in page.html_content
+            or 'class="language-mermaid"' in page.html_content
+        )
         return self.render_template("page.html", page=page, **context)
 
     def render_index(
@@ -276,6 +284,11 @@ class TemplateRenderer:
         Returns:
             Rendered HTML string
         """
+        context["has_mermaid"] = any(
+            'class="mermaid"' in p.html_content
+            or 'class="language-mermaid"' in p.html_content
+            for p in posts
+        )
         return self.render_template(
             "index.html",
             posts=posts,
@@ -304,6 +317,11 @@ class TemplateRenderer:
         Returns:
             Rendered HTML string
         """
+        context["has_mermaid"] = any(
+            'class="mermaid"' in p.html_content
+            or 'class="language-mermaid"' in p.html_content
+            for p in posts
+        )
         return self.render_template(
             "archive.html",
             posts=posts,
@@ -333,6 +351,11 @@ class TemplateRenderer:
         Returns:
             Rendered HTML string
         """
+        context["has_mermaid"] = any(
+            'class="mermaid"' in p.html_content
+            or 'class="language-mermaid"' in p.html_content
+            for p in posts
+        )
         return self.render_template(
             "tag.html",
             tag=tag,
@@ -362,6 +385,11 @@ class TemplateRenderer:
         Returns:
             Rendered HTML string
         """
+        context["has_mermaid"] = any(
+            'class="mermaid"' in p.html_content
+            or 'class="language-mermaid"' in p.html_content
+            for p in posts
+        )
         return self.render_template(
             "category.html",
             category=category,
@@ -391,6 +419,11 @@ class TemplateRenderer:
         Returns:
             Rendered HTML string
         """
+        context["has_mermaid"] = any(
+            'class="mermaid"' in p.html_content
+            or 'class="language-mermaid"' in p.html_content
+            for p in posts
+        )
         return self.render_template(
             "series.html",
             series=series,

--- a/src/blogmore/site_config.py
+++ b/src/blogmore/site_config.py
@@ -296,6 +296,13 @@ class SiteConfig:
     include_drafts: bool = False
     """Whether to include draft posts in generation."""
 
+    with_mermaid: bool = False
+    """Whether to enable Mermaid diagram rendering.
+
+    This is a **configuration file only** option — it cannot be set on the
+    command line.  Off by default.
+    """
+
     show_toc: bool = True
     """Whether to show the Table of Contents on posts by default.
 

--- a/src/blogmore/templates/base.html
+++ b/src/blogmore/templates/base.html
@@ -66,7 +66,7 @@
     <script src="{{ codeblocks_js_url }}" defer></script>
     {% if with_mermaid and has_mermaid %}
     <script type="module">
-        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
 
         // Helper to check if dark mode is active
         function isDarkTheme() {

--- a/src/blogmore/templates/base.html
+++ b/src/blogmore/templates/base.html
@@ -64,6 +64,68 @@
     <script src="{{ theme_js_url }}"></script>
     {% endif %}
     <script src="{{ codeblocks_js_url }}" defer></script>
+    {% if with_mermaid and has_mermaid %}
+    <script type="module">
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+
+        // Helper to check if dark mode is active
+        function isDarkTheme() {
+            return document.documentElement.getAttribute('data-theme') === 'dark' ||
+                (!document.documentElement.getAttribute('data-theme') &&
+                 window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        }
+
+        // Save original diagram code before Mermaid replaces it
+        const elements = document.querySelectorAll('.mermaid');
+        elements.forEach(el => {
+            el.setAttribute('data-original-code', el.textContent);
+        });
+
+        // Initialize with active theme
+        mermaid.initialize({
+            startOnLoad: false,
+            theme: isDarkTheme() ? 'dark' : 'default',
+            securityLevel: 'loose'
+        });
+
+        mermaid.run();
+
+        // Listen for real-time theme changes and dynamically re-render diagrams
+        const themeObserver = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.attributeName === 'data-theme') {
+                    const currentDark = isDarkTheme();
+                    mermaid.initialize({
+                        startOnLoad: false,
+                        theme: currentDark ? 'dark' : 'default',
+                        securityLevel: 'loose'
+                    });
+
+                    const elList = document.querySelectorAll('.mermaid');
+                    let needsReRun = false;
+                    elList.forEach(el => {
+                        const original = el.getAttribute('data-original-code');
+                        if (original) {
+                            el.removeAttribute('data-processed');
+                            el.removeAttribute('id');
+                            el.textContent = original;
+                            needsReRun = true;
+                        }
+                    });
+
+                    if (needsReRun) {
+                        mermaid.run();
+                    }
+                }
+            });
+        });
+
+        themeObserver.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-theme']
+        });
+    </script>
+    {% endif %}
     {% if prev_page_url %}<link rel="prev" href="{{ prev_page_url }}">{% endif %}
     {% if next_page_url %}<link rel="next" href="{{ next_page_url }}">{% endif %}
     {% block extra_head %}{% endblock %}

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -1,0 +1,81 @@
+"""Unit tests for the Mermaid Markdown extension."""
+
+import markdown
+
+from blogmore.markdown.mermaid import MermaidExtension
+
+
+class TestMermaidExtension:
+    """Tests for the MermaidExtension with markdown."""
+
+    def _make_md(self) -> markdown.Markdown:
+        """Build a Markdown instance with the extension under test.
+
+        Returns:
+            A configured Markdown instance.
+        """
+        return markdown.Markdown(extensions=[MermaidExtension()])
+
+    def test_mermaid_fenced_block(self) -> None:
+        """Test that a mermaid code block is converted to pre class="mermaid"."""
+        md = self._make_md()
+        content = """
+Here is a diagram:
+
+```mermaid
+graph TD
+    A[Start] --> B(Process)
+```
+
+And some text after.
+"""
+        html = md.convert(content)
+        assert (
+            '<pre class="mermaid">graph TD\n    A[Start] --&gt; B(Process)</pre>'
+            in html
+        )
+        assert "Here is a diagram:" in html
+        assert "And some text after." in html
+
+    def test_mermaid_multiple_blocks(self) -> None:
+        """Test that multiple mermaid code blocks in a single document are handled."""
+        md = self._make_md()
+        content = """
+```mermaid
+graph TD
+    A --> B
+```
+
+Middle text.
+
+```mermaid
+sequenceDiagram
+    Alice->>Bob: Hello
+```
+"""
+        html = md.convert(content)
+        assert '<pre class="mermaid">graph TD\n    A --&gt; B</pre>' in html
+        assert (
+            '<pre class="mermaid">sequenceDiagram\n    Alice-&gt;&gt;Bob: Hello</pre>'
+            in html
+        )
+        assert "Middle text." in html
+
+    def test_mermaid_non_closed_fence(self) -> None:
+        """Test a mermaid fence that does not close."""
+        md = self._make_md()
+        content = """
+```mermaid
+graph TD
+    A --> B
+"""
+        html = md.convert(content)
+        assert "graph TD" in html
+        assert "mermaid" in html
+
+    def test_makeextension_returns_instance(self) -> None:
+        """Test that makeExtension returns a MermaidExtension instance."""
+        from blogmore.markdown.mermaid import makeExtension
+
+        ext = makeExtension()
+        assert isinstance(ext, MermaidExtension)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1814,3 +1814,150 @@ class TestTemplateRenderer:
 
         assert "🚧" not in html
         assert "draft-title" not in html
+
+    def test_render_post_with_mermaid(self, sample_post: Post) -> None:
+        """Test rendering a post with mermaid enabled and containing diagram."""
+        renderer = TemplateRenderer()
+
+        # When Mermaid is disabled (with_mermaid=False)
+        html_disabled = renderer.render_post(
+            sample_post,
+            with_mermaid=False,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" not in html_disabled
+
+        # When Mermaid is enabled but post doesn't have diagram
+        html_enabled_no_diag = renderer.render_post(
+            sample_post,
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" not in html_enabled_no_diag
+
+        # When Mermaid is enabled and post has diagram
+        sample_post_with_diag = Post(
+            path=sample_post.path,
+            title=sample_post.title,
+            content=sample_post.content,
+            html_content='<pre class="mermaid">graph TD\n A --&gt; B</pre>',
+            date=sample_post.date,
+            category=sample_post.category,
+            tags=sample_post.tags,
+            series=sample_post.series,
+            draft=sample_post.draft,
+            metadata=sample_post.metadata,
+            toc_html=sample_post.toc_html,
+            show_toc=sample_post.show_toc,
+            show_toc_inline=sample_post.show_toc_inline,
+            redirect_from=sample_post.redirect_from,
+        )
+        html_enabled_with_diag = renderer.render_post(
+            sample_post_with_diag,
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" in html_enabled_with_diag
+
+    def test_render_page_with_mermaid(self, sample_page: Page) -> None:
+        """Test rendering a page with mermaid enabled and containing diagram."""
+        renderer = TemplateRenderer()
+
+        # When Mermaid is disabled
+        html_disabled = renderer.render_page(
+            sample_page,
+            with_mermaid=False,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" not in html_disabled
+
+        # When Mermaid is enabled but page has no diagram
+        html_enabled_no_diag = renderer.render_page(
+            sample_page,
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" not in html_enabled_no_diag
+
+        # When Mermaid is enabled and page has diagram
+        sample_page_with_diag = Page(
+            path=sample_page.path,
+            title=sample_page.title,
+            content=sample_page.content,
+            html_content='<pre class="mermaid">graph TD\n A --&gt; B</pre>',
+            metadata=sample_page.metadata,
+            toc_html=sample_page.toc_html,
+            show_toc=sample_page.show_toc,
+            show_toc_inline=sample_page.show_toc_inline,
+            redirect_from=sample_page.redirect_from,
+        )
+        html_enabled_with_diag = renderer.render_page(
+            sample_page_with_diag,
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" in html_enabled_with_diag
+
+    def test_render_listings_with_mermaid(self, sample_post: Post) -> None:
+        """Test rendering index and other listing pages with mermaid enabled and containing diagram."""
+        renderer = TemplateRenderer()
+
+        sample_post_with_diag = Post(
+            path=sample_post.path,
+            title=sample_post.title,
+            content=sample_post.content,
+            html_content='<pre class="mermaid">graph TD\n A --&gt; B</pre>',
+            date=sample_post.date,
+            category=sample_post.category,
+            tags=sample_post.tags,
+            series=sample_post.series,
+            draft=sample_post.draft,
+            metadata=sample_post.metadata,
+            toc_html=sample_post.toc_html,
+            show_toc=sample_post.show_toc,
+            show_toc_inline=sample_post.show_toc_inline,
+            redirect_from=sample_post.redirect_from,
+        )
+
+        # Index page
+        html_index = renderer.render_index(
+            posts=[sample_post_with_diag],
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" in html_index
+
+        # Archive page
+        html_archive = renderer.render_archive(
+            posts=[sample_post_with_diag],
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" in html_archive
+
+        # Tag page
+        html_tag = renderer.render_tag_page(
+            tag="python",
+            posts=[sample_post_with_diag],
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" in html_tag
+
+        # Category page
+        html_category = renderer.render_category_page(
+            category="coding",
+            posts=[sample_post_with_diag],
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" in html_category
+
+        # Series page
+        html_series = renderer.render_series_page(
+            series="tutorials",
+            posts=[sample_post_with_diag],
+            with_mermaid=True,
+            site_title="Test Blog",
+        )
+        assert "https://cdn.jsdelivr.net/npm/mermaid" in html_series


### PR DESCRIPTION
Disabled by default; enabled using `with_mermaid`.

<img width="347" height="233" alt="Screenshot 2026-06-06 at 15 48 45" src="https://github.com/user-attachments/assets/6a2a7ac4-aeb8-43f7-82e9-3c61f81b5144" />

<img width="790" height="681" alt="Screenshot 2026-06-06 at 15 47 19" src="https://github.com/user-attachments/assets/f01685a8-b64e-4c80-9a40-d46305a4bf94" /> 

Designed so the script that does the rendering is only pulled into a page that contains a Mermaid diagram; so any page not showing one should never need to load the code.