### PR TITLE
Add support for sub-commands to the `post` command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # BlogMore ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Restructured the `dump` command to support subcommands, converting the
+  original post-dumping functionality into a `dump posts` subcommand while
+  maintaining `posts` as the default subcommand for backward compatibility.
+  ([#609](https://github.com/davep/blogmore/pull/609))
+
 ## v2.41.0
 
 **Released: 2026-06-07**

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -17,7 +17,7 @@ BlogMore provides several commands:
 - **`publish`** - Build and publish the site to a git branch
 - **`lint`** - Check the site for common issues (broken links, etc.)
 - **`drafts`** - List the path to all posts marked as drafts
-- **`dump`** - Dump all posts to stdout as JSON in posting time order
+- **`dump`** - Dump site content to stdout as JSON (defaults to `posts`)
 - **`cache`** - Manage the BlogMore cache
 
 ### Command Aliases
@@ -592,20 +592,34 @@ blogmore drafts posts/
 
 ## Dump Command
 
-Dump all blog posts to stdout as a JSON array in posting time order (oldest first). This is a utility command that includes all available properties of each post, making it easy to integrate with custom external tools or scripts.
+Dump site content to stdout as JSON. This is a utility command to export site data for integration with custom external tools or scripts.
 
 ### Synopsis
 
 ```bash
-blogmore dump [content_dir] [options]
+blogmore dump <subcommand> [content_dir] [options]
 ```
 
-### Arguments
+To maintain backward compatibility, running `blogmore dump` without a subcommand defaults to `dump posts`.
+
+### Subcommands
+
+#### `posts`
+
+Dump all blog posts to stdout as a JSON array in posting time order (oldest first). This includes all available properties of each post.
+
+##### Synopsis
+
+```bash
+blogmore dump posts [content_dir] [options]
+```
+
+##### Arguments
 
 **`content_dir`** (optional)
 : Directory containing your Markdown blog posts.
 
-### Output Properties
+##### Output Properties
 
 Each post in the dumped JSON array is represented by an object containing the following properties:
 
@@ -640,9 +654,14 @@ Each post in the dumped JSON array is represented by an object containing the fo
 | `gfi` | `float` | The Gunning Fog Index readability score for the post's prose (0.0 if empty). |
 | `modified_date` | `string` or `null` | The modified date and time of the post in ISO format, or `null` if not set in metadata. |
 
-### Examples
+##### Examples
 
-Dump all posts to a JSON file:
+Dump all posts to a JSON file explicitly:
+```bash
+blogmore dump posts posts/ > blog_dump.json
+```
+
+Or using the default subcommand:
 ```bash
 blogmore dump posts/ > blog_dump.json
 ```

--- a/src/blogmore/__main__.py
+++ b/src/blogmore/__main__.py
@@ -24,10 +24,91 @@ from blogmore.server import serve_site
 from blogmore.site_config import SiteConfig, site_config_defaults
 
 
-def main() -> int:
-    """Main entry point for the blogmore CLI."""
+def preprocess_args(argv: list[str]) -> list[str]:
+    """Preprocess CLI arguments to insert the default subcommand for dump.
+
+    If `dump` is specified but no subcommand is provided, this function
+    inserts `posts` as the default subcommand.
+
+    Args:
+        argv: The list of command-line arguments.
+
+    Returns:
+        The preprocessed list of command-line arguments.
+    """
+    new_argv = list(argv)
+    if not new_argv or new_argv[0] != "dump":
+        return new_argv
+
+    dump_idx = 0
+    dump_args = new_argv[1:]
+
+    # Option flags that take an argument, used to distinguish them from subcommands.
+    options_with_args = {
+        "-c",
+        "--config",
+        "-t",
+        "--templates",
+        "-o",
+        "--output",
+        "--site-title",
+        "--site-subtitle",
+        "--site-description",
+        "--site-keywords",
+        "--site-url",
+        "--posts-per-feed",
+        "--extra-stylesheet",
+        "--default-author",
+        "--default-author-url",
+        "--icon-source",
+        "-p",
+        "--port",
+        "--branch",
+        "--remote",
+        "--delay",
+    }
+
+    known_subcommands = {"posts"}
+    has_subcommand = False
+
+    i = 0
+    while i < len(dump_args):
+        arg = dump_args[i]
+        if arg in ("-h", "--help"):
+            # If the user is asking for help, let argparse handle it.
+            return new_argv
+        if arg.startswith("-"):
+            if arg in options_with_args:
+                i += 2
+            else:
+                i += 1
+        else:
+            if arg in known_subcommands:
+                has_subcommand = True
+            break
+
+    if not has_subcommand:
+        new_argv.insert(dump_idx + 1, "posts")
+
+    return new_argv
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for the blogmore CLI.
+
+    Args:
+        argv: Optional list of command-line arguments to parse (excluding the
+            program name). If not provided, sys.argv[1:] will be used.
+
+    Returns:
+        The exit code of the command.
+    """
+    argv = sys.argv[1:] if argv is None else list(argv)
+
+    argv = preprocess_args(argv)
+
     parser = create_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Expand user home directory in path arguments from CLI
     if hasattr(args, "content_dir") and args.content_dir is not None:
@@ -243,52 +324,56 @@ def main() -> int:
 
     # Handle dump command
     if args.command == "dump":
-        # Validate that content_dir is provided
-        if args.content_dir is None:
-            print_error(
-                "Error: content_dir is required. Specify it on the command line or in the config file."
-            )
-            return 1
+        if args.dump_command == "posts":
+            # Validate that content_dir is provided
+            if args.content_dir is None:
+                print_error(
+                    "Error: content_dir is required. Specify it on the command line or in the config file."
+                )
+                return 1
 
-        # Validate inputs
-        if not args.content_dir.exists():
-            print_error(f"Error: Content directory not found: {args.content_dir}")
-            return 1
+            # Validate inputs
+            if not args.content_dir.exists():
+                print_error(f"Error: Content directory not found: {args.content_dir}")
+                return 1
 
-        try:
-            from blogmore.dump import dump_posts
-            from blogmore.generator.paths import resolve_post_output_paths
-            from blogmore.parser import PostParser
+            try:
+                from blogmore.dump import dump_posts
+                from blogmore.generator.paths import resolve_post_output_paths
+                from blogmore.parser import PostParser
 
-            post_parser = PostParser(
-                site_url=site_config.site_url,
-                default_show_toc=site_config.show_toc,
-                default_show_toc_inline=site_config.show_toc_inline,
-                with_mermaid=site_config.with_mermaid,
-                with_maths=site_config.with_maths,
-            )
-            posts = post_parser.parse_directory(
-                args.content_dir,
-                include_drafts=site_config.include_drafts,
-                exclude_dirs=[args.content_dir / "pages"],
-            )
+                post_parser = PostParser(
+                    site_url=site_config.site_url,
+                    default_show_toc=site_config.show_toc,
+                    default_show_toc_inline=site_config.show_toc_inline,
+                    with_mermaid=site_config.with_mermaid,
+                    with_maths=site_config.with_maths,
+                )
+                posts = post_parser.parse_directory(
+                    args.content_dir,
+                    include_drafts=site_config.include_drafts,
+                    exclude_dirs=[args.content_dir / "pages"],
+                )
 
-            # Resolve paths to populate post.url_path and post.url correctly
-            resolve_post_output_paths(site_config, posts)
+                # Resolve paths to populate post.url_path and post.url correctly
+                resolve_post_output_paths(site_config, posts)
 
-            for post in posts:
-                post.words_per_minute = site_config.read_time_wpm
+                for post in posts:
+                    post.words_per_minute = site_config.read_time_wpm
 
-            if site_config.with_related:
-                from blogmore.similarity import SimilarityEngine
+                if site_config.with_related:
+                    from blogmore.similarity import SimilarityEngine
 
-                similarity_engine = SimilarityEngine(site_config)
-                similarity_engine.calculate_related_posts(posts)
+                    similarity_engine = SimilarityEngine(site_config)
+                    similarity_engine.calculate_related_posts(posts)
 
-            dump_posts(posts, args.content_dir, site_url=site_config.site_url)
-            return 0
-        except Exception as e:
-            print_error(f"Error dumping posts: {e}")
+                dump_posts(posts, args.content_dir, site_url=site_config.site_url)
+                return 0
+            except Exception as e:
+                print_error(f"Error dumping posts: {e}")
+                return 1
+        else:
+            parser.print_help()
             return 1
 
     # Handle lint command

--- a/src/blogmore/cli.py
+++ b/src/blogmore/cli.py
@@ -331,17 +331,29 @@ def create_parser() -> argparse.ArgumentParser:
     # Dump command
     dump_parser = subparsers.add_parser(
         "dump",
+        help="Dump site content to stdout as JSON",
+        description="Dump site content to stdout as JSON",
+    )
+
+    dump_subparsers = dump_parser.add_subparsers(
+        dest="dump_command",
+        help="Type of content to dump",
+    )
+
+    # Dump posts sub-command
+    posts_parser = dump_subparsers.add_parser(
+        "posts",
         help="Dump all posts to stdout as JSON in posting time order",
     )
 
-    dump_parser.add_argument(
+    posts_parser.add_argument(
         "content_dir",
         type=Path,
         nargs="?",
         help="Directory containing markdown blog posts",
     )
 
-    add_common_arguments(dump_parser)
+    add_common_arguments(posts_parser)
 
     # Cache command
     cache_parser = subparsers.add_parser(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3145,3 +3145,111 @@ class TestDumpCLI:
             assert result == 1
             captured = capsys.readouterr()
             assert "Error: Content directory not found" in captured.err
+
+    def test_dump_posts_explicit(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """Test that explicit dump posts command works identical to dump command."""
+        posts_dir = tmp_path / "posts"
+        posts_dir.mkdir()
+        temp_output_dir = tmp_path / "output"
+        temp_output_dir.mkdir()
+
+        post_file = posts_dir / "first.md"
+        post_file.write_text(
+            "---\n"
+            "title: First Post\n"
+            "date: 2024-01-15\n"
+            "---\n"
+            "Content of the first post.\n"
+        )
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "blogmore",
+                "dump",
+                "posts",
+                str(posts_dir),
+                "-o",
+                str(temp_output_dir),
+            ],
+        ):
+            result = main()
+            assert result == 0
+            captured = capsys.readouterr()
+
+            import json
+
+            data = json.loads(captured.out)
+            assert len(data) == 1
+            assert data[0]["title"] == "First Post"
+
+    def test_dump_help_does_not_insert_posts(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Test that dump help does not automatically insert posts subcommand."""
+        with patch.object(
+            sys,
+            "argv",
+            ["blogmore", "dump", "-h"],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            captured = capsys.readouterr()
+            assert "posts" in captured.out
+            assert "Dump site content to stdout" in captured.out
+
+    def test_preprocess_args_cases(self) -> None:
+        """Test the preprocess_args utility with various input scenarios."""
+        from blogmore.__main__ import preprocess_args
+
+        # Case 1: dump with no args -> dump posts
+        assert preprocess_args(["dump"]) == ["dump", "posts"]
+
+        # Case 2: dump posts -> unchanged
+        assert preprocess_args(["dump", "posts"]) == ["dump", "posts"]
+
+        # Case 3: dump posts content_dir -> unchanged
+        assert preprocess_args(["dump", "posts", "my_posts"]) == [
+            "dump",
+            "posts",
+            "my_posts",
+        ]
+
+        # Case 4: dump content_dir -> dump posts content_dir
+        assert preprocess_args(["dump", "my_posts"]) == ["dump", "posts", "my_posts"]
+
+        # Case 5: dump -c config.yaml my_posts -> dump posts -c config.yaml my_posts
+        assert preprocess_args(["dump", "-c", "config.yaml", "my_posts"]) == [
+            "dump",
+            "posts",
+            "-c",
+            "config.yaml",
+            "my_posts",
+        ]
+
+        # Case 6: dump --site-title posts -> dump posts --site-title posts
+        assert preprocess_args(["dump", "--site-title", "posts"]) == [
+            "dump",
+            "posts",
+            "--site-title",
+            "posts",
+        ]
+
+        # Case 7: dump -h -> unchanged
+        assert preprocess_args(["dump", "-h"]) == ["dump", "-h"]
+
+        # Case 8: dump posts -h -> unchanged
+        assert preprocess_args(["dump", "posts", "-h"]) == ["dump", "posts", "-h"]
+
+        # Case 9: other command -> unchanged
+        assert preprocess_args(["build", "posts"]) == ["build", "posts"]
+
+        # Case 10: links dump -> unchanged
+        assert preprocess_args(["links", "dump"]) == ["links", "dump"]


### PR DESCRIPTION
Also ensure that `posts` is the default for `dump`, maintaining backward compatibility. So:

- `blogmore dump`
- `blogmore dump posts`

are both the same command.

Implements the core requirement of #606.